### PR TITLE
chore: lessen warnings on unwanted edns types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ working_dir
 __pycache__/
 *.py[cod]
 dist/
+
+.idea/
+.python-version

--- a/nodestream_akamai/akamai_utils/addresses.py
+++ b/nodestream_akamai/akamai_utils/addresses.py
@@ -1,0 +1,46 @@
+"""Common utils for getting information about addresses."""
+from enum import StrEnum
+from ipaddress import ip_address, IPv4Address, IPv6Address
+
+
+class AddressNodeType(StrEnum):
+    CIDRIPV4 = "Cidripv4"
+    CIDRIPV6 = "Cidripv6"
+    ENDPOINT = "Endpoint"
+
+
+class AddressFormat(StrEnum):
+    IPV4 = "ipv4"
+    IPV6 = "ipv6"
+    ENDPOINT = "endpoint"
+    INVALID = "Invalid"
+
+    @property
+    def node_type(self) -> AddressNodeType:
+        """Get the node type for this kind of address"""
+        return ADDRESS_FORMAT_TO_NODE_TYPE.get(self)
+
+
+ADDRESS_FORMAT_TO_NODE_TYPE = {
+    AddressFormat.IPV4: AddressNodeType.CIDRIPV4,
+    AddressFormat.IPV6: AddressNodeType.CIDRIPV6,
+    AddressFormat.ENDPOINT: AddressNodeType.ENDPOINT,
+}
+
+
+def get_format(address: int | str | bytes | IPv4Address | IPv6Address) -> AddressFormat:
+    """Figure out the format type of the address"""
+    try:
+        ip_addr = ip_address(address)
+    except ValueError:
+        ip_addr = address
+
+    match ip_addr:
+        case IPv4Address(_):
+            return AddressFormat.IPV4
+        case IPv6Address(_):
+            return AddressFormat.IPV6
+        case other if " " in other:
+            return AddressFormat.INVALID
+        case _:
+            return AddressFormat.ENDPOINT

--- a/nodestream_akamai/akamai_utils/client.py
+++ b/nodestream_akamai/akamai_utils/client.py
@@ -106,7 +106,7 @@ class AkamaiApiClient:
         }
 
         if isinstance(headers, dict):
-            for header in headers.keys():
+            for header in headers:
                 request_headers[header] = headers[header]
 
         for sleepy_seconds in range(5):
@@ -140,7 +140,8 @@ class AkamaiApiClient:
             yield elem
             seen.add(k)
 
-    def _resilient_session_factory(self, timeout=300, retry_count=5) -> Session:
+    @staticmethod
+    def _resilient_session_factory(timeout=300, retry_count=5) -> Session:
         session = Session()
         retries = Retry(
             total=retry_count, backoff_factor=0.5, status_forcelist=[500, 502, 503, 504]

--- a/nodestream_akamai/gtm/gtm.py
+++ b/nodestream_akamai/gtm/gtm.py
@@ -1,87 +1,72 @@
 import logging
-from ipaddress import IPv4Address, ip_address
 
 from nodestream.pipeline.extractors import Extractor
 
+from ..akamai_utils import addresses
 from ..akamai_utils.gtm_client import AkamaiGtmClient
+
+PARSED_PROPERTY_TYPES = [
+    "weighted-round-robin",
+    "weighted-hashed",
+    "weighted-round-robin-load-feedback",
+    "ranked-failover",
+    "failover",
+    "performance",
+]
+DEEPLINK_PREFIX = "https://control.akamai.com/apps/gtm/#/domains/"
 
 
 class AkamaiGtmExtractor(Extractor):
     def __init__(self, **akamai_client_kwargs) -> None:
         self.client = AkamaiGtmClient(**akamai_client_kwargs)
         self.logger = logging.getLogger(self.__class__.__name__)
-        # We only extract linked ipv4, ipv6 and endpoint types from these property types
-        self.PARSED_PROPERTY_TYPES = [
-            "weighted-round-robin",
-            "weighted-hashed",
-            "weighted-round-robin-load-feedback",
-            "ranked-failover",
-            "failover",
-            "performance",
-        ]
-        self.DEEPLINK_PREFIX = "https://control.akamai.com/apps/gtm/#/domains/"
-        self.ADDRESS_FORMAT_TO_NODE_TYPE = {
-            "ipv4": "Cidripv4",
-            "ipv6": "Cidripv6",
-            "endpoint": "Endpoint",
-        }
-
-    def _get_address_format(self, address):
-        try:
-            if type(ip_address(address)) is IPv4Address:
-                return "ipv4"
-            else:
-                return "ipv6"
-        except ValueError:
-            if " " in address:
-                return "Invalid"
-            else:
-                return "endpoint"
 
     async def extract_records(self):
         for domain in self.client.list_gtm_domains():
             try:
                 raw_domain = self.client.get_gtm_domain(domain["name"])
             except Exception as err:
-                self.logger.error(f"Failed to get gtm domain: {domain['name']}")
-                self.logger.error(err)
+                self.logger.error(
+                    "Failed to get gtm domain: %s",
+                    domain["name"],
+                    exc_info=True,
+                )
+                raise err
 
-            deeplink = f'{self.DEEPLINK_PREFIX}{domain["name"]}/properties/list'
+            deeplink = f'{DEEPLINK_PREFIX}{domain["name"]}/properties/list'
             properties = []
-            for property in raw_domain["properties"]:
-                fqdn = property["name"] + "." + raw_domain["name"]
+            for prop in raw_domain["properties"]:
                 out_property = {
-                    "fqdn": fqdn,
-                    "type": property["type"],
-                    "name": property["name"],
+                    "fqdn": f'{prop["name"]}.{raw_domain["name"]}',
+                    "type": prop["type"],
+                    "name": prop["name"],
                     "Endpoint": [],
                     "Cidripv4": [],
                     "Cidripv6": [],
                 }
 
-                if property["type"] in self.PARSED_PROPERTY_TYPES:
-                    for traffic_target in property["trafficTargets"]:
+                if prop["type"] in PARSED_PROPERTY_TYPES:
+                    for traffic_target in prop["trafficTargets"]:
                         if len(traffic_target["servers"]) > 0:
                             for server in traffic_target["servers"]:
-                                address_format = self._get_address_format(server)
-                                node_type = self.ADDRESS_FORMAT_TO_NODE_TYPE.get(
-                                    address_format
-                                )
+                                address_format = addresses.get_format(server)
+                                node_type = address_format.node_type
                                 if node_type:
                                     out_property[node_type].append(server)
                         if traffic_target["handoutCName"]:
                             out_property["Endpoint"].append(
                                 traffic_target["handoutCName"]
                             )
-                for rrset in property["staticRRSets"]:
+                for rrset in prop["staticRRSets"]:
                     for record in rrset["rdata"]:
-                        address_format = self._get_address_format(record)
-                        node_type = self.ADDRESS_FORMAT_TO_NODE_TYPE.get(address_format)
+                        address_format = addresses.get_format(record)
+                        node_type = address_format.node_type
                         if node_type:
                             out_property[node_type].append(record)
 
                 properties.append(out_property)
-            parsed_domain = {
+
+            yield {
                 "name": raw_domain["name"],
                 "properties": properties,
                 "type": raw_domain["type"],
@@ -90,4 +75,3 @@ class AkamaiGtmExtractor(Extractor):
                 "cnameCoalescingEnabled": raw_domain["cnameCoalescingEnabled"],
                 "deeplink": deeplink,
             }
-            yield parsed_domain


### PR DESCRIPTION
We were getting a lot of `WARNING: Identity value for source node was null. Skipping Ingest.` when running the edns against our Akamai endpoints here.

In order to prevent these, I modified the edns extractor to not emit `AkamaiEdnsRecordSet` where the type was not in the allowed type list.