### PR TITLE
fix: edns not saving any resolves_to relationships

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ run:
 
 .PHONY: fmt
 fmt:
-	poetry run isort nodestream_akamai
-	poetry run black nodestream_akamai
+	poetry run isort nodestream_akamai tests
+	poetry run black nodestream_akamai tests
+
+.PHONY: test
+test:
+	poetry run pytest
 

--- a/nodestream_akamai/akamai_utils/client.py
+++ b/nodestream_akamai/akamai_utils/client.py
@@ -35,7 +35,6 @@ class AkamaiApiClient:
         self, path, params=None, headers=None, backoff_index=None
     ):
         full_url = urljoin(self.base_url, path)
-        logger.info("Exec: %s", full_url)
 
         backoff_delays = [5, 10, 20, 60, 180]
         if backoff_index is None:
@@ -92,7 +91,6 @@ class AkamaiApiClient:
 
     def _post_api_from_relative_path(self, path, body, params=None, headers=None):
         full_url = urljoin(self.base_url, path)
-        logger.info("Exec: %s", full_url)
 
         # Insert account switch key
         if self.account_key is not None:

--- a/nodestream_akamai/edns/edns.py
+++ b/nodestream_akamai/edns/edns.py
@@ -33,7 +33,9 @@ class AkamaiEdnsExtractor(Extractor):
             address_format = addresses.get_format(record)
             node_type = address_format.node_type
             if node_type:
-                recordset.get(node_type, []).append(record)
+                node_type_list = recordset.get(node_type, [])
+                node_type_list.append(record)
+                recordset[node_type] = node_type_list
         return recordset
 
     async def _extract_zone(self, zone):

--- a/tests/edns/test_edns.py
+++ b/tests/edns/test_edns.py
@@ -1,0 +1,182 @@
+import asyncio
+from typing import AsyncGenerator
+
+import pytest
+import responses
+
+from nodestream_akamai.edns import edns
+
+
+@pytest.fixture
+def edns_extractor():
+    return edns.AkamaiEdnsExtractor(
+        base_url="https://fake.example.com",
+        client_token="ctoken",
+        client_secret="secret",
+        access_token="atoken",
+    )
+
+
+async def to_list_async(generator: AsyncGenerator):
+    output = []
+    async for record in generator:
+        output.append(record)
+    return output
+
+
+@responses.activate
+def test_extract_records(edns_extractor):
+    """Happy path check"""
+    rsp1 = responses.Response(
+        method="GET",
+        url="https://fake.example.com/config-dns/v2/zones?showAll=true",
+        status=200,
+        json={
+            "zones": [
+                {
+                    "zone": "test-zone-1",
+                },
+                {
+                    "zone": "test-zone-2",
+                },
+            ]
+        },
+    )
+    responses.add(rsp1)
+
+    rsp2 = responses.Response(
+        method="GET",
+        url="https://fake.example.com/config-dns/v2/zones/test-zone-1/recordsets?showAll=true",
+        status=200,
+        json={
+            "recordsets": [
+                {
+                    "name": "rs-1",
+                    "type": "PRIMARY",
+                    "rdata": ["Not", "Going", "To", "Make", "It"],
+                },
+                {"name": "rs-2", "type": "CNAME", "rdata": ["Hello"]},
+                {"name": "rs-3", "type": "A", "rdata": ["192.168.1.1"]},
+            ]
+        },
+    )
+    responses.add(rsp2)
+
+    rsp3 = responses.Response(
+        method="GET",
+        url="https://fake.example.com/config-dns/v2/zones/test-zone-2/recordsets?showAll=true",
+        status=200,
+        json={
+            "recordsets": [
+                {
+                    "name": "rs-4",
+                    "type": "AAAA",
+                    "rdata": [
+                        "3271:9297:1824:7ed9:9f9d:3535:4b3c:8274",
+                        "dce8:a12b:d609:f7d8:fb8c:2b68:68d4:bf6b",
+                    ],
+                },
+                {"name": "rs-5", "type": "CNAME", "rdata": ["Goodbye"]},
+                {"name": "rs-6", "type": "A", "rdata": ["192.168.1.2"]},
+            ]
+        },
+    )
+    responses.add(rsp3)
+
+    result = asyncio.run(to_list_async(edns_extractor.extract_records()))
+    assert result == [
+        {
+            "recordsets": [
+                {
+                    "Endpoint": ["Hello"],
+                    "key": "rs-2/CNAME",
+                    "name": "rs-2",
+                    "rdata": ["Hello"],
+                    "type": "CNAME",
+                    "zone": "test-zone-1",
+                },
+                {
+                    "Cidripv4": ["192.168.1.1"],
+                    "key": "rs-3/A",
+                    "name": "rs-3",
+                    "rdata": ["192.168.1.1"],
+                    "type": "A",
+                    "zone": "test-zone-1",
+                },
+            ],
+            "zone": "test-zone-1",
+        },
+        {
+            "recordsets": [
+                {
+                    "Cidripv6": [
+                        "3271:9297:1824:7ed9:9f9d:3535:4b3c:8274",
+                        "dce8:a12b:d609:f7d8:fb8c:2b68:68d4:bf6b",
+                    ],
+                    "key": "rs-4/AAAA",
+                    "name": "rs-4",
+                    "rdata": [
+                        "3271:9297:1824:7ed9:9f9d:3535:4b3c:8274",
+                        "dce8:a12b:d609:f7d8:fb8c:2b68:68d4:bf6b",
+                    ],
+                    "type": "AAAA",
+                    "zone": "test-zone-2",
+                },
+                {
+                    "Endpoint": ["Goodbye"],
+                    "key": "rs-5/CNAME",
+                    "name": "rs-5",
+                    "rdata": ["Goodbye"],
+                    "type": "CNAME",
+                    "zone": "test-zone-2",
+                },
+                {
+                    "Cidripv4": ["192.168.1.2"],
+                    "key": "rs-6/A",
+                    "name": "rs-6",
+                    "rdata": ["192.168.1.2"],
+                    "type": "A",
+                    "zone": "test-zone-2",
+                },
+            ],
+            "zone": "test-zone-2",
+        },
+    ]
+
+
+@responses.activate
+def test_extract_records_zone_fetch_fail(edns_extractor):
+    rsp1 = responses.Response(
+        method="GET",
+        url="https://fake.example.com/config-dns/v2/zones?showAll=true",
+        status=400,
+    )
+    responses.add(rsp1)
+
+    with pytest.raises(Exception):
+        asyncio.run(to_list_async(edns_extractor.extract_records()))
+
+
+@responses.activate
+def test_extract_records_recordsets_fetch_fail(edns_extractor):
+    rsp1 = responses.Response(
+        method="GET",
+        url="https://fake.example.com/config-dns/v2/zones?showAll=true",
+        status=200,
+        json={
+            "zones": [
+                {
+                    "zone": "test-zone-error",
+                }
+            ]
+        },
+    )
+    responses.add(rsp1)
+    rsp2 = responses.Response(
+        method="GET",
+        url="https://fake.example.com/config-dns/v2/zones/test-zone-error/recordsets?showAll=true",
+        status=400,
+    )
+    responses.add(rsp2)
+    with pytest.raises(Exception):
+        asyncio.run(to_list_async(edns_extractor.extract_records()))


### PR DESCRIPTION
One of the updates to prevent warnings was overzealous, and the `(AkamaiRecordSet)-[RESOLVES_TO]->(*)` was not being saved back to the dict properly.

Added a test to prove the fix.