### PR TITLE
fix: incorrect keyname format in appsec_coverage

### DIFF
--- a/nodestream_akamai/appsec_coverage/appsec_coverage.py
+++ b/nodestream_akamai/appsec_coverage/appsec_coverage.py
@@ -5,6 +5,19 @@ from nodestream.pipeline.extractors import Extractor
 from ..akamai_utils.appsec_client import AkamaiAppSecClient
 
 
+def _extract_policy(covering_config, hostname, policy_name) -> dict[str, str]:
+    covering_policy = next(
+        policy
+        for policy in covering_config["policies"]
+        if policy["policyName"] == policy_name
+    )
+    return {
+        "hostname": hostname["hostname"],
+        "policy_name": covering_policy["policyName"],
+        "policyId": covering_policy["policyId"],
+    }
+
+
 class AkamaiAppSecCoverageExtractor(Extractor):
     def __init__(self, **akamai_client_kwargs) -> None:
         self.client = AkamaiAppSecClient(**akamai_client_kwargs)
@@ -25,7 +38,7 @@ class AkamaiAppSecCoverageExtractor(Extractor):
 
         for hostname in hostname_coverage:
             # Only care if hostname is covered
-            if hostname["status"] == "covered":
+            if hostname.get("status") == "covered":
                 # Need to find policy ID, so find first locate config from hostname entry
                 covering_config = next(
                     config
@@ -34,14 +47,7 @@ class AkamaiAppSecCoverageExtractor(Extractor):
                 )
                 # Then iterate through policyNames and replace with dict
                 for policy_name in hostname["policyNames"]:
-                    covering_policy = next(
-                        policy
-                        for policy in covering_config["policies"]
-                        if policy["policy_name"] == policy_name
+                    coverage_object = _extract_policy(
+                        covering_config, hostname, policy_name
                     )
-                    coverage_object = {
-                        "hostname": hostname["hostname"],
-                        "policy_name": covering_policy["policy_name"],
-                        "policyId": covering_policy["policyId"],
-                    }
                     yield coverage_object

--- a/tests/appsec_coverage/test_appsec_coverage.py
+++ b/tests/appsec_coverage/test_appsec_coverage.py
@@ -1,0 +1,44 @@
+from nodestream_akamai.appsec_coverage.appsec_coverage import _extract_policy
+
+hostname = {
+    "configuration": {
+        "id": 11111,
+        "name": "ExampleCorp - WAF Security File",
+        "version": 42,
+    },
+    "hasMatchTarget": True,
+    "hostname": "other.example.com",
+    "policyNames": ["Production"],
+    "status": "covered",
+}
+
+covering_config = {
+    "fileType": "RBAC",
+    "id": 11111,
+    "latestVersion": 43,
+    "name": "ExampleCorp - WAF Security File",
+    "productionHostnames": [
+        "*.other.example.com",
+        "*.other.other.example.com",
+        "*.us1.other.example.com",
+        "admin.example.com",
+        "api-login.example.com",
+        "apidocs.example.com",
+        "blog.example.com",
+        "campaigns.example.com",
+        "other.example.com",
+    ],
+    "productionVersion": 42,
+    "stagingVersion": 42,
+    "targetProduct": "EXAMPLE",
+    "policies": [{"policyId": "waf1_123456", "policyName": "Production"}],
+}
+
+
+def test__extract_policy():
+
+    assert _extract_policy(covering_config, hostname, "Production") == {
+        "hostname": "other.example.com",
+        "policy_name": "Production",
+        "policyId": "waf1_123456",
+    }


### PR DESCRIPTION
when reading the covering config, it was trying to access the key `policy_name` instead of `policyName`.

Fixed this and added a test to prove the fix.