### PR TITLE
fix: handle recursion correctly after backoff retries for 429 responses

### DIFF
--- a/tests/akamai_utils/test_client.py
+++ b/tests/akamai_utils/test_client.py
@@ -1,0 +1,36 @@
+import pytest
+import responses
+
+from nodestream_akamai.akamai_utils.client import AkamaiApiClient
+
+
+@pytest.fixture
+def client():
+    client = AkamaiApiClient(
+        base_url="https://fake.example.com",
+        client_token="ctoken",
+        client_secret="secret",
+        access_token="atoken",
+    )
+    client.backoff_delays = [0, 0, 0, 0, 0]
+    return client
+
+
+@responses.activate
+def test_429_get_response(client):
+    rsp1 = responses.Response(
+        method="GET",
+        url="https://fake.example.com/example",
+        status=429,
+    )
+    rsp2 = responses.Response(
+        method="GET",
+        url="https://fake.example.com/example",
+        status=200,
+        json={"key": "value"},
+    )
+    responses.add(rsp1)
+    responses.add(rsp1)
+    responses.add(rsp2)
+
+    assert client._get_api_from_relative_path("example") == {"key": "value"}


### PR DESCRIPTION
When a 429 is recieved for a GET call, the recursion caused the response object to get reassigned to the JSON on success.

To fix this, we should return the result of the recursion immediately because it is no longer a `requests.Response object`

Error message showing this error:
~~~
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/nodestream_akamai/waf/waf.py", line 32, in extract_records
    export = self.client.export_appsec_config(
        config_id=config["id"],
        config_version=config["productionVersion"],
    )
  File "/usr/local/lib/python3.13/site-packages/nodestream_akamai/akamai_utils/appsec_client.py", line 29, in export_appsec_config
    return self._get_api_from_relative_path(export_config_path)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/nodestream_akamai/akamai_utils/client.py", line 77, in _get_api_from_relative_path
    response = self._get_api_from_relative_path(
        path,
    ...<2 lines>...
        backoff_index=next_backoff_index,
    )
  File "/usr/local/lib/python3.13/site-packages/nodestream_akamai/akamai_utils/client.py", line 77, in _get_api_from_relative_path
    response = self._get_api_from_relative_path(
        path,
    ...<2 lines>...
        backoff_index=next_backoff_index,
    )
  File "/usr/local/lib/python3.13/site-packages/nodestream_akamai/akamai_utils/client.py", line 77, in _get_api_from_relative_path
    response = self._get_api_from_relative_path(
        path,
    ...<2 lines>...
        backoff_index=next_backoff_index,
    )
  File "/usr/local/lib/python3.13/site-packages/nodestream_akamai/akamai_utils/client.py", line 85, in _get_api_from_relative_path
    if response.status_code == 200:
       ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'status_code'
~~~