### PR TITLE
Stripping trailing dot from record names

### DIFF
--- a/nodestream_akamai/akamai_utils/property_client.py
+++ b/nodestream_akamai/akamai_utils/property_client.py
@@ -564,7 +564,11 @@ class AkamaiPropertyClient(AkamaiApiClient):
         instances = self.search_akamai_rule_tree_for_behavior(rule_tree, "edgeWorker")
         ew_ids = []
         for behavior in instances:
-            ew_ids.append(int(behavior["options"]["edgeWorkerId"]))
+            if (
+                "edgeWorkerId" in behavior["options"]
+                and behavior["options"]["edgeWorkerId"]
+            ):
+                ew_ids.append(int(behavior["options"]["edgeWorkerId"]))
 
         return list(set(ew_ids))
 


### PR DESCRIPTION
Was likely preventing linking to existing endpoints