### PR TITLE
Added policy name property to graph

### DIFF
--- a/nodestream_akamai/waf.yaml
+++ b/nodestream_akamai/waf.yaml
@@ -32,3 +32,4 @@
       iterate_on: !jmespath 'policies[*]'
       node_properties:
         deeplink: !jmespath 'deeplink'
+        policy_name: !jmespath 'policyName'


### PR DESCRIPTION
The Akamai policy node does not show the policy name which is useful information.
I added the policy name as a property to the node.