### PR TITLE
Adding tag extraction to property client

### DIFF
--- a/nodestream_akamai/akamai_utils/model.py
+++ b/nodestream_akamai/akamai_utils/model.py
@@ -30,6 +30,7 @@ class PropertyDescription:
     deeplink: str | None = None
     cloudlet_policies: List[int] = field(default_factory=list)
     cp_codes: List[int] = field(default_factory=list)
+    tags: str | None = None
 
     @property
     def origin_count(self):

--- a/nodestream_akamai/akamai_utils/property_client.py
+++ b/nodestream_akamai/akamai_utils/property_client.py
@@ -1,4 +1,5 @@
 import itertools
+import json
 import logging
 import re
 from typing import Any, List, Tuple
@@ -254,6 +255,17 @@ class AkamaiPropertyClient(AkamaiApiClient):
             rule_tree=rule_tree["rules"]
         )
 
+        # Tags
+        tags = self.search_akamai_rule_tree_for_tags(rule_tree=rule_tree["rules"])
+        # -- Format
+        if tags:
+            # Attempt to convert to dict, then back to minimised json
+            try:
+                tags_dict = json.loads(tags)
+                tags = json.dumps(tags_dict, separators=(",", ":"))
+            except json.JSONDecodeError:
+                tags = tags.strip()  # If not JSON, just strip whitespace
+
         # Deeplink
         deeplink_prefix = (
             "https://control.akamai.com/apps/property-manager/#/property-version/"
@@ -279,6 +291,7 @@ class AkamaiPropertyClient(AkamaiApiClient):
             hostnames=hostnames,
             deeplink=deeplink,
             cp_codes=cp_codes,
+            tags=tags,
         )
 
     def search_all_properties(self):
@@ -582,6 +595,23 @@ class AkamaiPropertyClient(AkamaiApiClient):
                 cpcode_ids.append(int(behavior["options"]["value"]["id"]))
 
         return list(set(cpcode_ids))
+
+    def search_akamai_rule_tree_for_tags(self, rule_tree: dict) -> str:
+        """
+        Extracts tags from the comments of any top-level rule named tags. Tags are expected to be in JSON format
+        """
+        tags_rule = [
+            rule for rule in rule_tree["children"] if rule["name"].lower() == "tags"
+        ]
+        tags = ""
+        if (
+            len(tags_rule) > 0
+            and "comments" in tags_rule[0]
+            and tags_rule[0]["comments"]
+        ):
+            tags = tags_rule[0]["comments"]
+
+        return tags
 
     def _get_property_response(self, property_id, hostnames):
         property_hostnames = [h for h in hostnames if h["propertyId"] == property_id]

--- a/nodestream_akamai/property.yaml
+++ b/nodestream_akamai/property.yaml
@@ -20,6 +20,7 @@
         version: !jmespath 'version'
         rule_format: !jmespath 'ruleFormat'
         deeplink: !jmespath 'deeplink'
+        tags: !jmespath 'tags'
     - type: relationship
       node_type: Endpoint
       node_key: 

--- a/tests/akamai_utils/rulesdata.py
+++ b/tests/akamai_utils/rulesdata.py
@@ -14,6 +14,14 @@ rule_tree_488011 = json.loads(
     "name": "default",
     "children": [
       {
+        "name": "Tags",
+        "children": [],
+        "behaviors": [],
+        "comments": "{\\"assetId\\": 12345, \\"test\\": \\"true\\"}",
+        "criteria": [],
+        "criteriaMustSatisfy": "all"
+      },
+      {
         "name": "Content Compression",
         "children": [],
         "behaviors": [

--- a/tests/akamai_utils/test_property_client.py
+++ b/tests/akamai_utils/test_property_client.py
@@ -51,7 +51,7 @@ CRITERIA_RULE = {
                 "behaviors": [
                     {"name": "gzipResponse", "options": {"behavior": "ALWAYS"}}
                 ],
-            }
+            },
         ],
     }
 }
@@ -74,7 +74,6 @@ def test_search_akamai_rule_tree_for_origins_simple(client):
 
 
 def test_search_akamai_rule_tree_for_origins(client):
-
     rule_tree = {
         "behaviors": [
             {
@@ -249,3 +248,10 @@ def test_live_search_akamai_rule_tree_for_cp_codes(client):
     assert client.search_akamai_rule_tree_for_cp_codes(rule_tree_643957["rules"]) == [
         752101
     ]
+
+
+def test_live_search_akamai_rule_tree_for_tags(client):
+    assert (
+        client.search_akamai_rule_tree_for_tags(rule_tree_488011["rules"])
+        == '{"assetId": 12345, "test": "true"}'
+    )


### PR DESCRIPTION
Client now looks for a top-level rule in Property Manager named "tags" whose comments text field is expected to be a json string of key/value pairs