### PR TITLE
fix(property-rule): key rules by structural path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ targets:
 1. Verify nodestream has loaded the pipelines: `poetry run nodestream show`
 1. Use nodestream to run the pipelines: `poetry run nodestream run <pipeline-name> --target my-db`
 
+# Property rule pipeline upgrades
+The `property-rule` pipeline keys `AkamaiPropertyRule` nodes by Akamai rule-tree
+position: `proxy_id + rule_path`. If your database was loaded by an older
+plugin version that keyed these nodes by rule name and hostname, do not rerun
+the pipeline yet. First rebuild the plugin-owned `AkamaiPropertyRule` subgraph,
+then create the new constraint, then rerun the pipeline. Otherwise Neo4j can
+keep the old `rule_path IS NULL` nodes and create a parallel set keyed by
+`rule_path`. Old nodes do not have enough data to reconstruct `rule_path`
+safely.
+
+To find databases that still contain old property-rule data:
+
+```cypher
+MATCH (r:AkamaiPropertyRule)
+WHERE r.rule_path IS NULL
+RETURN count(r) AS old_rule_nodes
+```
+
 # Using make
 1. Install make (ie. `brew install make`)
 1. Run `make run`

--- a/nodestream_akamai/akamai_utils/model.py
+++ b/nodestream_akamai/akamai_utils/model.py
@@ -150,6 +150,8 @@ class PropertyRuleRecord:
     ]  # baseDirectory prefix prepended unconditionally; None = no prefix
 
     # Rule metadata
+    # snake_case mirrors the graph property; API-shaped fields keep existing names.
+    rule_path: str  # JSON Pointer path in the rule tree, e.g. /rules/children/0
     ruleName: str
     ruleDepth: int  # 0 = default/root rule
     criteriaMustSatisfy: str  # "all" | "any"

--- a/nodestream_akamai/akamai_utils/model.py
+++ b/nodestream_akamai/akamai_utils/model.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+# Akamai/PAPI-facing records intentionally keep API-shaped field names.
+# Pipeline YAML maps those emitted keys to graph snake_case properties.
+
 
 @dataclass(eq=True, frozen=True, kw_only=True)
 class EdgeHost:
@@ -150,8 +153,8 @@ class PropertyRuleRecord:
     ]  # baseDirectory prefix prepended unconditionally; None = no prefix
 
     # Rule metadata
-    # snake_case mirrors the graph property; API-shaped fields keep existing names.
-    rule_path: str  # JSON Pointer path in the rule tree, e.g. /rules/children/0
+    # Output field stays API-shaped; YAML maps it onto graph property rule_path.
+    rulePath: str  # JSON Pointer path in the rule tree, e.g. /rules/children/0
     ruleName: str
     ruleDepth: int  # 0 = default/root rule
     criteriaMustSatisfy: str  # "all" | "any"

--- a/nodestream_akamai/akamai_utils/property_client.py
+++ b/nodestream_akamai/akamai_utils/property_client.py
@@ -694,6 +694,7 @@ class AkamaiPropertyClient(AkamaiApiClient):
         inheritedOriginType: str | None = None,
         inheritedOutboundPath: str | None = None,
         inheritedBaseDirectory: str | None = None,
+        rule_path: str = "/rules",
     ) -> list:
         """Recursively extract PropertyRuleRecord objects from a rule tree node.
 
@@ -759,6 +760,7 @@ class AkamaiPropertyClient(AkamaiApiClient):
                     originType=originType,
                     outboundPath=outboundPath,
                     baseDirectory=baseDirectory,
+                    rule_path=rule_path,
                     ruleName=ruleName,
                     ruleDepth=depth,
                     criteriaMustSatisfy=rule.get("criteriaMustSatisfy", "all"),
@@ -770,10 +772,10 @@ class AkamaiPropertyClient(AkamaiApiClient):
                 )
             )
 
-        for childRule in rule.get("children", []):
+        for child_index, child_rule in enumerate(rule.get("children", [])):
             records.extend(
                 self.extractRuleRecords(
-                    rule=childRule,
+                    rule=child_rule,
                     propertyId=propertyId,
                     propertyName=propertyName,
                     version=version,
@@ -785,6 +787,7 @@ class AkamaiPropertyClient(AkamaiApiClient):
                     inheritedOriginType=originType,
                     inheritedOutboundPath=outboundPath,
                     inheritedBaseDirectory=baseDirectory,
+                    rule_path=f"{rule_path}/children/{child_index}",
                 )
             )
 

--- a/nodestream_akamai/akamai_utils/property_client.py
+++ b/nodestream_akamai/akamai_utils/property_client.py
@@ -1,7 +1,7 @@
 import itertools
 import logging
 import re
-from typing import Any, List, Tuple
+from typing import Any, ClassVar, List, Tuple
 
 from jsonpath_ng.ext import parse
 
@@ -13,6 +13,9 @@ from .model import (
     PropertyDescription,
     PropertyRuleRecord,
 )
+
+# Client methods and emitted records mirror Akamai/PAPI naming at the boundary.
+# Pipeline YAML maps those API-shaped fields to graph snake_case properties.
 
 PATH_AND = " AND "
 
@@ -551,7 +554,7 @@ class AkamaiPropertyClient(AkamaiApiClient):
 
     # ── Rule-level extraction (Proxy schema) ──────────────────────────
 
-    SECURITY_BEHAVIOR_MAP = {
+    SECURITY_BEHAVIOR_MAP: ClassVar[dict[str, str]] = {
         "edgeAuth": "AKAMAI_EDGE_AUTH",
         "tokenAuth": "AKAMAI_TOKEN_AUTH",
         "siteShield": "AKAMAI_SITE_SHIELD",
@@ -575,30 +578,30 @@ class AkamaiPropertyClient(AkamaiApiClient):
 
         Both default to None when the respective behavior is absent.
         """
-        outboundPath = None
-        baseDirectory = None
+        outbound_path = None
+        base_directory = None
 
         for behavior in behaviors:
-            behaviorName = behavior.get("name", "")
+            behavior_name = behavior.get("name", "")
             options = behavior.get("options", {})
 
-            if behaviorName == "rewriteUrl" and outboundPath is None:
+            if behavior_name == "rewriteUrl" and outbound_path is None:
                 mode = options.get("behavior", "")
                 if mode == "REPLACE":
-                    outboundPath = f"REPLACE:{options.get('match','')}→{options.get('targetPath','')}"
+                    outbound_path = f"REPLACE:{options.get('match','')}→{options.get('targetPath','')}"
                 elif mode == "REMOVE":
-                    outboundPath = f"REMOVE:{options.get('match','')}"
+                    outbound_path = f"REMOVE:{options.get('match','')}"
                 elif mode == "REWRITE":
-                    outboundPath = f"REWRITE:{options.get('targetUrl','')}"
+                    outbound_path = f"REWRITE:{options.get('targetUrl','')}"
                 elif mode == "PREPEND":
-                    outboundPath = f"PREPEND:{options.get('targetPathPrepend','')}"
+                    outbound_path = f"PREPEND:{options.get('targetPathPrepend','')}"
                 elif mode == "REGEX_REPLACE":
-                    outboundPath = f"REGEX:{options.get('matchRegex','')}→{options.get('targetRegex','')}"
+                    outbound_path = f"REGEX:{options.get('matchRegex','')}→{options.get('targetRegex','')}"
 
-            elif behaviorName == "baseDirectory" and baseDirectory is None:
-                baseDirectory = options.get("value")
+            elif behavior_name == "baseDirectory" and base_directory is None:
+                base_directory = options.get("value")
 
-        return outboundPath, baseDirectory
+        return outbound_path, base_directory
 
     def extractSecurityBehaviors(self, behaviors: list) -> list:
         """Return normalized security behavior names from a rule's behavior list.
@@ -614,7 +617,7 @@ class AkamaiPropertyClient(AkamaiApiClient):
         return result
 
     def extractRuleCriteria(self, rule: dict) -> tuple:
-        """Return (pathCriteria, hostnameCriteria, conditionalOriginId) for one rule.
+        """Return (path_criteria, hostname_criteria, conditional_origin_id) for one rule.
 
         pathCriteria and hostnameCriteria are List[str] where each element is a
         single pattern — positive or !-negated.  They are NOT joined with AND so
@@ -622,28 +625,28 @@ class AkamaiPropertyClient(AkamaiApiClient):
 
         conditionalOriginId is the cloudletsOrigin originId if present, else None.
         """
-        pathCriteria = []
-        hostnameCriteria = []
-        conditionalOriginId = None
+        path_criteria = []
+        hostname_criteria = []
+        conditional_origin_id = None
 
         for criterion in rule.get("criteria", []):
-            criterionName = criterion["name"]
+            criterion_name = criterion["name"]
             options = criterion.get("options", {})
-            isNegative = options.get("matchOperator") in NEGATIVE_OPERATORS
+            is_negative = options.get("matchOperator") in NEGATIVE_OPERATORS
 
-            if criterionName == "path":
+            if criterion_name == "path":
                 for value in options.get("values", []):
-                    pathCriteria.append(f"!{value}" if isNegative else value)
-            elif criterionName == "hostname":
+                    path_criteria.append(f"!{value}" if is_negative else value)
+            elif criterion_name == "hostname":
                 for value in options.get("values", []):
-                    hostnameCriteria.append(f"!{value}" if isNegative else value)
-            elif criterionName == "cloudletsOrigin":
+                    hostname_criteria.append(f"!{value}" if is_negative else value)
+            elif criterion_name == "cloudletsOrigin":
                 # originId is a scalar, not a list
-                originId = options.get("originId")
-                if originId:
-                    conditionalOriginId = originId
+                origin_id = options.get("originId")
+                if origin_id:
+                    conditional_origin_id = origin_id
 
-        return pathCriteria, hostnameCriteria, conditionalOriginId
+        return path_criteria, hostname_criteria, conditional_origin_id
 
     def resolveOriginFromBehaviors(
         self,
@@ -671,14 +674,18 @@ class AkamaiPropertyClient(AkamaiApiClient):
 
         Own declaration takes precedence over inherited values.
         """
-        ownOutboundPath, ownBaseDirectory = self.extractOutboundPath(behaviors)
-        outboundPath = (
-            ownOutboundPath if ownOutboundPath is not None else inheritedOutboundPath
+        own_outbound_path, own_base_directory = self.extractOutboundPath(behaviors)
+        outbound_path = (
+            own_outbound_path
+            if own_outbound_path is not None
+            else inheritedOutboundPath
         )
-        baseDirectory = (
-            ownBaseDirectory if ownBaseDirectory is not None else inheritedBaseDirectory
+        base_directory = (
+            own_base_directory
+            if own_base_directory is not None
+            else inheritedBaseDirectory
         )
-        return outboundPath, baseDirectory
+        return outbound_path, base_directory
 
     def extractRuleRecords(
         self,
@@ -720,51 +727,53 @@ class AkamaiPropertyClient(AkamaiApiClient):
         """
         behaviors = rule.get("behaviors", [])
 
-        ownPathCriteria, ownHostnameCriteria, conditionalOriginId = (
+        own_path_criteria, own_hostname_criteria, conditional_origin_id = (
             self.extractRuleCriteria(rule)
         )
 
-        combinedPathCriteria = (inheritedPathCriteria or []) + ownPathCriteria
-        combinedHostnameCriteria = (
+        combined_path_criteria = (inheritedPathCriteria or []) + own_path_criteria
+        combined_hostname_criteria = (
             inheritedHostnameCriteria or []
-        ) + ownHostnameCriteria
+        ) + own_hostname_criteria
 
-        originHostname, originType = self.resolveOriginFromBehaviors(
+        origin_hostname, origin_type = self.resolveOriginFromBehaviors(
             behaviors, inheritedOriginHostname, inheritedOriginType
         )
 
-        securityBehaviors = self.extractSecurityBehaviors(behaviors)
+        security_behaviors = self.extractSecurityBehaviors(behaviors)
 
-        outboundPath, baseDirectory = self.resolveOutboundPathFromBehaviors(
+        outbound_path, base_directory = self.resolveOutboundPathFromBehaviors(
             behaviors, inheritedOutboundPath, inheritedBaseDirectory
         )
 
-        ruleName = rule.get("name", "default")
+        rule_name = rule.get("name", "default")
 
-        isPathEligible = bool(combinedPathCriteria) and conditionalOriginId is None
-        canonicalPath = (
-            PATH_AND.join(sorted(combinedPathCriteria)) if isPathEligible else None
+        is_path_eligible = (
+            bool(combined_path_criteria) and conditional_origin_id is None
+        )
+        canonical_path = (
+            PATH_AND.join(sorted(combined_path_criteria)) if is_path_eligible else None
         )
 
         records = []
 
         # Only emit records if there is a genuine origin to route to
-        if originHostname is not None:
+        if origin_hostname is not None:
             records.append(
                 PropertyRuleRecord(
-                    path=canonicalPath,
-                    pathCriteria=combinedPathCriteria,
-                    hostnameCriteria=combinedHostnameCriteria,
-                    conditionalOriginId=conditionalOriginId,
-                    originHostname=originHostname,
-                    originType=originType,
-                    outboundPath=outboundPath,
-                    baseDirectory=baseDirectory,
-                    rule_path=rule_path,
-                    ruleName=ruleName,
+                    path=canonical_path,
+                    pathCriteria=combined_path_criteria,
+                    hostnameCriteria=combined_hostname_criteria,
+                    conditionalOriginId=conditional_origin_id,
+                    originHostname=origin_hostname,
+                    originType=origin_type,
+                    outboundPath=outbound_path,
+                    baseDirectory=base_directory,
+                    rulePath=rule_path,
+                    ruleName=rule_name,
                     ruleDepth=depth,
                     criteriaMustSatisfy=rule.get("criteriaMustSatisfy", "all"),
-                    securityBehaviors=securityBehaviors,
+                    securityBehaviors=security_behaviors,
                     propertyId=propertyId,
                     propertyName=propertyName,
                     version=version,
@@ -781,12 +790,12 @@ class AkamaiPropertyClient(AkamaiApiClient):
                     version=version,
                     deeplink=deeplink,
                     depth=depth + 1,
-                    inheritedPathCriteria=combinedPathCriteria,
-                    inheritedHostnameCriteria=combinedHostnameCriteria,
-                    inheritedOriginHostname=originHostname,
-                    inheritedOriginType=originType,
-                    inheritedOutboundPath=outboundPath,
-                    inheritedBaseDirectory=baseDirectory,
+                    inheritedPathCriteria=combined_path_criteria,
+                    inheritedHostnameCriteria=combined_hostname_criteria,
+                    inheritedOriginHostname=origin_hostname,
+                    inheritedOriginType=origin_type,
+                    inheritedOutboundPath=outbound_path,
+                    inheritedBaseDirectory=base_directory,
                     rule_path=f"{rule_path}/children/{child_index}",
                 )
             )

--- a/nodestream_akamai/akamai_utils/property_client.py
+++ b/nodestream_akamai/akamai_utils/property_client.py
@@ -280,12 +280,8 @@ class AkamaiPropertyClient(AkamaiApiClient):
 
         return hostnames
 
-    def list_all_properties(self) -> List[AkamaiPropertyResponse] | None:
-        try:
-            hostnames = self.listAccountHostnames()
-        except Exception as err:
-            logger.exception("Failed to list property hostnames: %s", err)
-            return None
+    def list_all_properties(self) -> List[AkamaiPropertyResponse]:
+        hostnames = self.listAccountHostnames()
 
         propertyIds = {hostname["propertyId"] for hostname in hostnames}
         return [

--- a/nodestream_akamai/property-rule.yaml
+++ b/nodestream_akamai/property-rule.yaml
@@ -91,7 +91,7 @@
           proxy_id: !jmespath 'ruleKey.proxy_id'
           rule_path: !jmespath 'ruleKey.rule_path'
         node_properties:
-          rule_path: !jmespath 'rule_path'
+          rule_path: !jmespath 'rulePath'
           rule_name: !jmespath 'ruleName'
           rule_depth: !jmespath 'ruleDepth'
           path_criteria: !jmespath 'pathCriteria'

--- a/nodestream_akamai/property-rule.yaml
+++ b/nodestream_akamai/property-rule.yaml
@@ -1,20 +1,19 @@
 # AkamaiProperty Proxy schema — rule-level pipeline
 #
-# Records are split into two node types based on criteria dimensionality:
+# Records can create two node views:
 #
-#   Path-only rules (pathCriteria non-empty, no hostname, no cloudlet):
+#   Path-eligible rules additionally create:
 #     (AkamaiProperty:Proxy)-[:HAS_PATH]->(Path)-[:ROUTES_TO]->(Endpoint)
 #     — identical key schema to IAGE: (proxy_id, path)
 #     — pathCriteria list is directly micromatch-compatible
 #
-#   All other rules (hostname-dimensional, cloudlet-conditional, catch-all):
+#   Every emitted Akamai rule creates:
 #     (AkamaiProperty:Proxy)-[:HAS_RULE]->(AkamaiPropertyRule)-[:ROUTES_TO]->(Endpoint)
-#     — keyed on (proxy_id, rule_name) since path may be absent
+#     — keyed on (proxy_id, rule_path) since semantic fields may repeat
 #
-# The null-key-drop behaviour of the nodestream interpreter is the guard:
-# passes that target Path use isPath=true records; passes targeting
-# AkamaiPropertyRule use isPath=false records. Records with null keys
-# are silently skipped, so each pass only writes what it owns.
+# The null-key-drop behaviour of the nodestream interpreter guards Path
+# passes: only path-eligible records have pathKey. AkamaiPropertyRule passes
+# use ruleKey, which every emitted rule record has.
 
 - implementation: nodestream_akamai.property_rule:AkamaiPropertyRuleExtractor
   arguments:
@@ -44,9 +43,9 @@
           name: !jmespath 'propertyName'
           version: !jmespath 'version'
 
-    # Pass 2a: AkamaiProperty -[HAS_PATH]-> Path  (path-only rules)
-    # pathKey is non-null only when isPath=true; null keys are dropped,
-    # so this pass silently skips non-path records.
+    # Pass 2a: AkamaiProperty -[HAS_PATH]-> Path
+    # pathKey is non-null only when the extractor emitted a canonical path;
+    # null keys are dropped, so this pass skips non-path-eligible records.
     - - type: source_node
         node_type: AkamaiProperty
         additional_types:
@@ -73,8 +72,8 @@
         relationship_properties:
           rule_name: !jmespath 'ruleName'
 
-    # Pass 2b: AkamaiProperty -[HAS_RULE]-> AkamaiPropertyRule  (non-path rules)
-    # ruleKey is non-null only when isPath=false.
+    # Pass 2b: AkamaiProperty -[HAS_RULE]-> AkamaiPropertyRule
+    # ruleKey identifies the rule's structural position in the rule tree.
     - - type: source_node
         node_type: AkamaiProperty
         additional_types:
@@ -90,9 +89,9 @@
           do_remove_trailing_dots: true
         node_key:
           proxy_id: !jmespath 'ruleKey.proxy_id'
-          rule_name: !jmespath 'ruleKey.rule_name'
-          hostname: !jmespath 'ruleKey.hostname'
+          rule_path: !jmespath 'ruleKey.rule_path'
         node_properties:
+          rule_path: !jmespath 'rule_path'
           rule_name: !jmespath 'ruleName'
           rule_depth: !jmespath 'ruleDepth'
           path_criteria: !jmespath 'pathCriteria'
@@ -105,7 +104,7 @@
         relationship_properties:
           rule_name: !jmespath 'ruleName'
 
-    # Pass 3a: Path -[ROUTES_TO]-> backend Endpoint  (path-only rules)
+    # Pass 3a: Path -[ROUTES_TO]-> backend Endpoint
     - - type: source_node
         node_type: Path
         normalization:
@@ -124,15 +123,14 @@
           path_criteria: !jmespath 'pathCriteria'
           origin_type: !jmespath 'originType'
 
-    # Pass 3b: AkamaiPropertyRule -[ROUTES_TO]-> backend Endpoint  (non-path rules)
+    # Pass 3b: AkamaiPropertyRule -[ROUTES_TO]-> backend Endpoint
     - - type: source_node
         node_type: AkamaiPropertyRule
         normalization:
           do_remove_trailing_dots: true
         key:
           proxy_id: !jmespath 'ruleKey.proxy_id'
-          rule_name: !jmespath 'ruleKey.rule_name'
-          hostname: !jmespath 'ruleKey.hostname'
+          rule_path: !jmespath 'ruleKey.rule_path'
       - type: relationship
         node_type: Endpoint
         relationship_type: ROUTES_TO
@@ -170,8 +168,7 @@
           do_remove_trailing_dots: true
         key:
           proxy_id: !jmespath 'ruleKey.proxy_id'
-          rule_name: !jmespath 'ruleKey.rule_name'
-          hostname: !jmespath 'ruleKey.hostname'
+          rule_path: !jmespath 'ruleKey.rule_path'
       - type: relationship
         node_type: AuthenticationPolicy
         relationship_type: USES_AUTHENTICATION_BEHAVIOR

--- a/nodestream_akamai/property_rule/property_rule.py
+++ b/nodestream_akamai/property_rule/property_rule.py
@@ -20,6 +20,9 @@ class AkamaiPropertyRuleExtractor(Extractor):
     that each unique combination of criteria maps to exactly one Path node.
     Rules with no path criteria (hostname-only, cloudlet, catch-all) emit one
     record with path=None — Rule node only, no Path node.
+
+    AkamaiPropertyRule is keyed by the rule's structural rule_path because rule
+    names and criteria are not unique in Akamai rule trees.
     """
 
     def __init__(self, **akamaiClientKwargs) -> None:
@@ -40,38 +43,32 @@ class AkamaiPropertyRuleExtractor(Extractor):
     def buildRuleKey(self, record: dict) -> dict:
         """Return the ruleKey dict for an AkamaiPropertyRule node.
 
-        hostname is included so that two rules with the same name but different
-        hostname criteria produce distinct AkamaiPropertyRule nodes. It is None
-        for rules with no hostname dimension.
+        rule_path is the rule's JSON Pointer position in the Akamai rule tree.
         """
-        firstHostname = (
-            record["hostnameCriteria"][0] if record["hostnameCriteria"] else None
-        )
         return {
             "proxy_id": record["propertyId"],
-            "rule_name": record["ruleName"],
-            "hostname": firstHostname,
+            "rule_path": record["rule_path"],
         }
 
-    async def extractRecordsForProperty(self, property: AkamaiPropertyResponse):
+    async def extractRecordsForProperty(self, akamai_property: AkamaiPropertyResponse):
         """Yield pipeline dicts for every rule record in one property."""
         self.logger.info(
             "extracting rule records for property %s (id=%s)",
-            property.propertyName,
-            property.propertyId,
+            akamai_property.propertyName,
+            akamai_property.propertyId,
         )
         ruleTree = self.client.get_rule_tree(
-            property_id=property.propertyId,
-            version=property.productionVersion,
-            contract_id=property.contractId,
-            group_id=property.groupId,
+            property_id=akamai_property.propertyId,
+            version=akamai_property.productionVersion,
+            contract_id=akamai_property.contractId,
+            group_id=akamai_property.groupId,
         )
         for ruleRecord in self.client.extractRuleRecords(
             rule=ruleTree["rules"],
-            propertyId=property.propertyId,
-            propertyName=property.propertyName,
-            version=property.productionVersion,
-            deeplink=property.deeplink,
+            propertyId=akamai_property.propertyId,
+            propertyName=akamai_property.propertyName,
+            version=akamai_property.productionVersion,
+            deeplink=akamai_property.deeplink,
         ):
             recordDict = dataclasses.asdict(ruleRecord)
             recordDict["pathKey"] = self.buildPathKey(recordDict)
@@ -86,15 +83,15 @@ class AkamaiPropertyRuleExtractor(Extractor):
             self.logger.exception("Failed to list properties: %s", err)
             raise
 
-        for property in properties or []:
-            if property is None or property.productionVersion is None:
+        for akamai_property in properties or []:
+            if akamai_property is None or akamai_property.productionVersion is None:
                 continue
             try:
-                async for recordDict in self.extractRecordsForProperty(property):
+                async for recordDict in self.extractRecordsForProperty(akamai_property):
                     yield recordDict
             except Exception:
                 self.logger.exception(
                     "Failed to extract rule records for property %s (id=%s)",
-                    property.propertyName,
-                    property.propertyId,
+                    akamai_property.propertyName,
+                    akamai_property.propertyId,
                 )

--- a/nodestream_akamai/property_rule/property_rule.py
+++ b/nodestream_akamai/property_rule/property_rule.py
@@ -25,11 +25,11 @@ class AkamaiPropertyRuleExtractor(Extractor):
     names and criteria are not unique in Akamai rule trees.
     """
 
-    def __init__(self, **akamaiClientKwargs) -> None:
-        self.client = AkamaiPropertyClient(**akamaiClientKwargs)
+    def __init__(self, **akamai_client_kwargs) -> None:
+        self.client = AkamaiPropertyClient(**akamai_client_kwargs)
         self.logger = logging.getLogger(self.__class__.__name__)
 
-    def buildPathKey(self, record: dict) -> dict | None:
+    def build_path_key(self, record: dict) -> dict | None:
         """Return the pathKey dict for a path-eligible rule, or None.
 
         pathKey is non-null iff path is set (path-eligible rule). The path
@@ -40,40 +40,42 @@ class AkamaiPropertyRuleExtractor(Extractor):
             return None
         return {"proxy_id": record["propertyId"], "path": record["path"]}
 
-    def buildRuleKey(self, record: dict) -> dict:
+    def build_rule_key(self, record: dict) -> dict:
         """Return the ruleKey dict for an AkamaiPropertyRule node.
 
         rule_path is the rule's JSON Pointer position in the Akamai rule tree.
         """
         return {
             "proxy_id": record["propertyId"],
-            "rule_path": record["rule_path"],
+            "rule_path": record["rulePath"],
         }
 
-    async def extractRecordsForProperty(self, akamai_property: AkamaiPropertyResponse):
+    async def extract_records_for_property(
+        self, akamai_property: AkamaiPropertyResponse
+    ):
         """Yield pipeline dicts for every rule record in one property."""
         self.logger.info(
             "extracting rule records for property %s (id=%s)",
             akamai_property.propertyName,
             akamai_property.propertyId,
         )
-        ruleTree = self.client.get_rule_tree(
+        rule_tree = self.client.get_rule_tree(
             property_id=akamai_property.propertyId,
             version=akamai_property.productionVersion,
             contract_id=akamai_property.contractId,
             group_id=akamai_property.groupId,
         )
-        for ruleRecord in self.client.extractRuleRecords(
-            rule=ruleTree["rules"],
+        for rule_record in self.client.extractRuleRecords(
+            rule=rule_tree["rules"],
             propertyId=akamai_property.propertyId,
             propertyName=akamai_property.propertyName,
             version=akamai_property.productionVersion,
             deeplink=akamai_property.deeplink,
         ):
-            recordDict = dataclasses.asdict(ruleRecord)
-            recordDict["pathKey"] = self.buildPathKey(recordDict)
-            recordDict["ruleKey"] = self.buildRuleKey(recordDict)
-            yield recordDict
+            record_dict = dataclasses.asdict(rule_record)
+            record_dict["pathKey"] = self.build_path_key(record_dict)
+            record_dict["ruleKey"] = self.build_rule_key(record_dict)
+            yield record_dict
 
     async def extract_records(self):
         self.logger.debug("extracting property rule records")
@@ -87,8 +89,10 @@ class AkamaiPropertyRuleExtractor(Extractor):
             if akamai_property is None or akamai_property.productionVersion is None:
                 continue
             try:
-                async for recordDict in self.extractRecordsForProperty(akamai_property):
-                    yield recordDict
+                async for record_dict in self.extract_records_for_property(
+                    akamai_property
+                ):
+                    yield record_dict
             except Exception:
                 self.logger.exception(
                     "Failed to extract rule records for property %s (id=%s)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,12 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [ "S101", "S106" ]
+# Akamai/PAPI-facing records keep API-shaped names; pipeline YAML maps them to
+# graph snake_case properties.
+"nodestream_akamai/akamai_utils/model.py" = [ "N802", "N815" ]
+"nodestream_akamai/akamai_utils/property_client.py" = [ "N802", "N803", "N806" ]
+# These tests mirror legacy camelCase client method names.
+"tests/akamai_utils/test_property_client.py" = [ "N802" ]
 
 
 [build-system]

--- a/tests/akamai_utils/test_extract_rule_records.py
+++ b/tests/akamai_utils/test_extract_rule_records.py
@@ -1,14 +1,14 @@
 """Tests for AkamaiPropertyClient.extractRuleRecords and extractRuleCriteria.
 
 Key invariants verified:
-  1. pathCriteria is a flat List[str] of individual glob patterns (micromatch-ready).
-  2. The path node key equals PATH_AND.join(pathCriteria) — stable, deterministic.
+  1. path_criteria is a flat List[str] of individual glob patterns (micromatch-ready).
+  2. The path node key equals PATH_AND.join(path_criteria) — stable, deterministic.
   3. Ancestor criteria are inherited (prepended) by child rules.
-  4. hostnameCriteria is kept separate from pathCriteria.
+  4. hostname_criteria is kept separate from path_criteria.
   5. Negated criteria are prefixed with "!" in the list elements.
   6. Path eligibility is true iff path criteria exist and no cloudlet conditional exists.
   7. Security behaviors are mapped to normalized names.
-  8. rule_path is the JSON Pointer location of the rule in the tree.
+  8. rulePath is the JSON Pointer location of the rule in the tree.
 """
 
 import pytest
@@ -30,18 +30,18 @@ def client():
 
 
 def _make_rule(
-    name, criteria=None, behaviors=None, children=None, criteriaMustSatisfy="all"
+    name, criteria=None, behaviors=None, children=None, criteria_must_satisfy="all"
 ):
     return {
         "name": name,
         "criteria": criteria or [],
         "behaviors": behaviors or [],
         "children": children or [],
-        "criteriaMustSatisfy": criteriaMustSatisfy,
+        "criteriaMustSatisfy": criteria_must_satisfy,
     }
 
 
-def _path_criterion(values, negative=False):
+def _path_criterion(values, *, negative=False):
     return {
         "name": "path",
         "options": {
@@ -51,7 +51,7 @@ def _path_criterion(values, negative=False):
     }
 
 
-def _hostname_criterion(values, negative=False):
+def _hostname_criterion(values, *, negative=False):
     return {
         "name": "hostname",
         "options": {
@@ -68,55 +68,55 @@ def _origin_behavior(hostname="backend.example.com", origin_type="CUSTOMER"):
     }
 
 
-def _security_behavior(name, enabled=True):
+def _security_behavior(name, *, enabled=True):
     return {"name": name, "options": {"enabled": enabled}}
 
 
 # ── extractRuleCriteria ────────────────────────────────────────────────────────
 
 
-def test_extractRuleCriteria_empty_rule(client):
+def test_extract_rule_criteria_empty_rule(client):
     rule = _make_rule("default")
-    pathCriteria, hostnameCriteria, conditionalOriginId = client.extractRuleCriteria(
-        rule
+    path_criteria, hostname_criteria, conditional_origin_id = (
+        client.extractRuleCriteria(rule)
     )
-    assert pathCriteria == []
-    assert hostnameCriteria == []
-    assert conditionalOriginId is None
+    assert path_criteria == []
+    assert hostname_criteria == []
+    assert conditional_origin_id is None
 
 
-def test_extractRuleCriteria_single_positive_path(client):
+def test_extract_rule_criteria_single_positive_path(client):
     rule = _make_rule("api", criteria=[_path_criterion(["/v1/*"])])
-    pathCriteria, hostnameCriteria, _ = client.extractRuleCriteria(rule)
-    assert pathCriteria == ["/v1/*"]
-    assert hostnameCriteria == []
+    path_criteria, hostname_criteria, _ = client.extractRuleCriteria(rule)
+    assert path_criteria == ["/v1/*"]
+    assert hostname_criteria == []
 
 
-def test_extractRuleCriteria_multiple_path_values_same_criterion(client):
+def test_extract_rule_criteria_multiple_path_values_same_criterion(client):
     """Multiple values in one criterion block = OR semantics = flat list elements."""
     rule = _make_rule("api", criteria=[_path_criterion(["/v1/*", "/v2/*"])])
-    pathCriteria, _, _ = client.extractRuleCriteria(rule)
+    path_criteria, _, _ = client.extractRuleCriteria(rule)
     # Each value is its own list element — not joined — micromatch-ready
-    assert pathCriteria == ["/v1/*", "/v2/*"]
+    assert path_criteria == ["/v1/*", "/v2/*"]
 
 
-def test_extractRuleCriteria_negative_path_prefixed(client):
+def test_extract_rule_criteria_negative_path_prefixed(client):
     rule = _make_rule(
         "no-sitemap",
         criteria=[_path_criterion(["/community/sitemap*.xml"], negative=True)],
     )
-    pathCriteria, _, _ = client.extractRuleCriteria(rule)
-    assert pathCriteria == ["!/community/sitemap*.xml"]
+    path_criteria, _, _ = client.extractRuleCriteria(rule)
+    assert path_criteria == ["!/community/sitemap*.xml"]
 
 
-def test_extractRuleCriteria_hostname_criterion_separate(client):
+def test_extract_rule_criteria_hostname_criterion_separate(client):
     rule = _make_rule("host-rule", criteria=[_hostname_criterion(["api.example.com"])])
-    pathCriteria, hostnameCriteria, _ = client.extractRuleCriteria(rule)
-    assert pathCriteria == []
-    assert hostnameCriteria == ["api.example.com"]
+    path_criteria, hostname_criteria, _ = client.extractRuleCriteria(rule)
+    assert path_criteria == []
+    assert hostname_criteria == ["api.example.com"]
 
 
-def test_extractRuleCriteria_mixed_path_and_hostname(client):
+def test_extract_rule_criteria_mixed_path_and_hostname(client):
     rule = _make_rule(
         "mixed",
         criteria=[
@@ -124,12 +124,12 @@ def test_extractRuleCriteria_mixed_path_and_hostname(client):
             _hostname_criterion(["api.example.com"]),
         ],
     )
-    pathCriteria, hostnameCriteria, _ = client.extractRuleCriteria(rule)
-    assert pathCriteria == ["/v1/*"]
-    assert hostnameCriteria == ["api.example.com"]
+    path_criteria, hostname_criteria, _ = client.extractRuleCriteria(rule)
+    assert path_criteria == ["/v1/*"]
+    assert hostname_criteria == ["api.example.com"]
 
 
-def test_extractRuleCriteria_cloudlets_origin_extracted(client):
+def test_extract_rule_criteria_cloudlets_origin_extracted(client):
     rule = _make_rule(
         "cloudlet-route",
         criteria=[
@@ -139,14 +139,14 @@ def test_extractRuleCriteria_cloudlets_origin_extracted(client):
             }
         ],
     )
-    _, _, conditionalOriginId = client.extractRuleCriteria(rule)
-    assert conditionalOriginId == "dc1_impot_ca_prod"
+    _, _, conditional_origin_id = client.extractRuleCriteria(rule)
+    assert conditional_origin_id == "dc1_impot_ca_prod"
 
 
 # ── extractRuleRecords: basic structure ───────────────────────────────────────
 
 
-def test_extractRuleRecords_default_rule_only(client):
+def test_extract_rule_records_default_rule_only(client):
     """Root rule with no criteria and an origin emits one record with path=None."""
     root = _make_rule("default", behaviors=[_origin_behavior("backend.example.com")])
     records = client.extractRuleRecords(
@@ -163,12 +163,12 @@ def test_extractRuleRecords_default_rule_only(client):
     assert r.pathCriteria == []
     assert r.hostnameCriteria == []
     assert r.originHostname == "backend.example.com"
-    assert r.rule_path == "/rules"
+    assert r.rulePath == "/rules"
     assert r.ruleDepth == 0
     assert r.ruleName == "default"
 
 
-def test_extractRuleRecords_single_child_path_rule(client):
+def test_extract_rule_records_single_child_path_rule(client):
     """Child with its own origin; root has no origin so only child is emitted."""
     child = _make_rule(
         "v1-api",
@@ -186,17 +186,17 @@ def test_extractRuleRecords_single_child_path_rule(client):
     # root has no origin → omitted; only child emitted
     assert len(records) == 1
     child_record = records[0]
-    assert child_record.rule_path == "/rules/children/0"
+    assert child_record.rulePath == "/rules/children/0"
     assert child_record.pathCriteria == ["/v1/*"]
     assert child_record.path == "/v1/*"
     assert child_record.ruleDepth == 1
     assert child_record.originHostname == "api-backend.example.com"
 
 
-def test_extractRuleRecords_compound_rule_emits_one_record(client):
+def test_extract_rule_records_compound_rule_emits_one_record(client):
     """A compound rule (positive + negation) emits exactly one record.
 
-    path = sorted pathCriteria joined with AND; full pathCriteria list
+    path = sorted path_criteria joined with AND; full path_criteria list
     is retained on the record for micromatch evaluation.
     """
     child = _make_rule(
@@ -219,8 +219,8 @@ def test_extractRuleRecords_compound_rule_emits_one_record(client):
     assert child_record.pathCriteria == ["/community/*", "!/community/sitemap*.xml"]
 
 
-def test_extractRuleRecords_criteria_inherited_from_ancestors(client):
-    """A grandchild rule's pathCriteria includes criteria from root → parent → child.
+def test_extract_rule_records_criteria_inherited_from_ancestors(client):
+    """A grandchild rule's path_criteria includes criteria from root → parent → child.
 
     Root and parent have no origin → both omitted. Grandchild emits one record
     with path = sorted AND-join of all accumulated criteria.
@@ -243,13 +243,13 @@ def test_extractRuleRecords_criteria_inherited_from_ancestors(client):
     # One record: path = sorted AND-join of inherited + own criteria
     assert len(records) == 1
     r = records[0]
-    assert r.rule_path == "/rules/children/0/children/0"
+    assert r.rulePath == "/rules/children/0/children/0"
     assert r.path == "/community/* AND /community/api/*"
     assert r.pathCriteria == ["/community/*", "/community/api/*"]
     assert r.ruleDepth == 2
 
 
-def test_extractRuleRecords_hostname_rule_not_path(client):
+def test_extract_rule_records_hostname_rule_not_path(client):
     """A rule with hostname criteria only (no path criteria) emits one record with path=None."""
     child = _make_rule(
         "host-rule",
@@ -269,7 +269,7 @@ def test_extractRuleRecords_hostname_rule_not_path(client):
     assert host_record.path is None
 
 
-def test_extractRuleRecords_pure_path_rule_is_path_eligible(client):
+def test_extract_rule_records_pure_path_rule_is_path_eligible(client):
     """A rule with only path criteria produces a record with a non-null path (Path-eligible)."""
     child = _make_rule(
         "v1",
@@ -285,7 +285,7 @@ def test_extractRuleRecords_pure_path_rule_is_path_eligible(client):
     assert r.path == "/v1/*"
 
 
-def test_extractRuleRecords_mixed_path_hostname_is_path_eligible(client):
+def test_extract_rule_records_mixed_path_hostname_is_path_eligible(client):
     """A rule with both path and hostname criteria still produces a Path node.
 
     Hostname scopes which ingress traffic hits the path, but the path glob itself
@@ -328,7 +328,7 @@ def test_extract_rule_records_duplicate_semantics_get_distinct_rule_paths(client
         rule=root, propertyId="501159", propertyName="p", version=1, deeplink=""
     )
 
-    assert [r.rule_path for r in records] == [
+    assert [r.rulePath for r in records] == [
         "/rules/children/0",
         "/rules/children/1",
     ]
@@ -346,7 +346,7 @@ def test_extract_rule_records_rule_path_keeps_skipped_child_indexes(client):
         rule=root, propertyId="prp_skip", propertyName="p", version=1, deeplink=""
     )
 
-    assert [r.rule_path for r in records] == [
+    assert [r.rulePath for r in records] == [
         "/rules/children/0",
         "/rules/children/2",
     ]
@@ -355,7 +355,7 @@ def test_extract_rule_records_rule_path_keeps_skipped_child_indexes(client):
 # ── Security behaviors ─────────────────────────────────────────────────────────
 
 
-def test_extractSecurityBehaviors_maps_known_names(client):
+def test_extract_security_behaviors_maps_known_names(client):
     behaviors = [
         _security_behavior("edgeAuth"),
         _security_behavior("siteShield"),
@@ -369,17 +369,17 @@ def test_extractSecurityBehaviors_maps_known_names(client):
     }
 
 
-def test_extractSecurityBehaviors_disabled_excluded(client):
+def test_extract_security_behaviors_disabled_excluded(client):
     behaviors = [_security_behavior("edgeAuth", enabled=False)]
     assert client.extractSecurityBehaviors(behaviors) == []
 
 
-def test_extractSecurityBehaviors_unknown_behavior_ignored(client):
+def test_extract_security_behaviors_unknown_behavior_ignored(client):
     behaviors = [{"name": "gzipResponse", "options": {"enabled": True}}]
     assert client.extractSecurityBehaviors(behaviors) == []
 
 
-def test_extractRuleRecords_security_behaviors_on_record(client):
+def test_extract_rule_records_security_behaviors_on_record(client):
     """Security behaviors found in a rule are included in the record."""
     child = _make_rule(
         "protected",
@@ -400,8 +400,8 @@ def test_extractRuleRecords_security_behaviors_on_record(client):
 # ── Micromatch compatibility invariant ────────────────────────────────────────
 
 
-def test_pathCriteria_elements_have_no_AND_separator(client):
-    """No individual pathCriteria element should contain PATH_AND — that would
+def test_path_criteria_elements_have_no_and_separator(client):
+    """No individual path_criteria element should contain PATH_AND — that would
     mean AND-joined strings leaked into the list, making them incompatible with
     micromatch's pattern-per-element expectation."""
     child = _make_rule(
@@ -416,18 +416,18 @@ def test_pathCriteria_elements_have_no_AND_separator(client):
     records = client.extractRuleRecords(
         rule=root, propertyId="prp_mc", propertyName="p", version=1, deeplink=""
     )
-    # One record (one rule); pathCriteria list elements must never contain PATH_AND
+    # One record (one rule); path_criteria list elements must never contain PATH_AND
     assert len(records) == 1
     for r in records:
         for element in r.pathCriteria:
             assert PATH_AND not in element, (
-                f"pathCriteria element {element!r} contains PATH_AND — "
+                f"path_criteria element {element!r} contains PATH_AND — "
                 "would break micromatch compatibility"
             )
 
 
 def test_path_is_canonical_sorted_and_join(client):
-    """path is the sorted pathCriteria joined with AND — one record per rule."""
+    """path is the sorted path_criteria joined with AND — one record per rule."""
     child = _make_rule(
         "multi",
         criteria=[
@@ -450,7 +450,7 @@ def test_path_is_canonical_sorted_and_join(client):
 # ── Origin inheritance ─────────────────────────────────────────────────────────
 
 
-def test_extractRuleRecords_child_inherits_root_origin(client):
+def test_extract_rule_records_child_inherits_root_origin(client):
     """Child with no own origin inherits origin from root (default rule)."""
     child = _make_rule(
         "v1-api",
@@ -475,7 +475,7 @@ def test_extractRuleRecords_child_inherits_root_origin(client):
     assert child_record.pathCriteria == ["/v1/*"]
 
 
-def test_extractRuleRecords_grandchild_inherits_root_origin(client):
+def test_extract_rule_records_grandchild_inherits_root_origin(client):
     """Grandchild inherits origin from root when neither parent nor grandchild re-declare one."""
     grandchild = _make_rule(
         "community-api",
@@ -506,7 +506,7 @@ def test_extractRuleRecords_grandchild_inherits_root_origin(client):
     assert gc_records[0].pathCriteria == ["/community/*", "/community/api/*"]
 
 
-def test_extractRuleRecords_child_origin_overrides_inherited(client):
+def test_extract_rule_records_child_origin_overrides_inherited(client):
     """Child that re-declares its own origin uses it, not the inherited one."""
     child = _make_rule(
         "v1-api",
@@ -526,7 +526,7 @@ def test_extractRuleRecords_child_origin_overrides_inherited(client):
     assert records[1].originHostname == "child-backend.example.com"
 
 
-def test_extractRuleRecords_no_origin_anywhere_emits_nothing(client):
+def test_extract_rule_records_no_origin_anywhere_emits_nothing(client):
     """A rule tree with no origin behaviors at any level emits zero records."""
     child = _make_rule("v1-api", criteria=[_path_criterion(["/v1/*"])])
     root = _make_rule("default", children=[child])
@@ -547,66 +547,66 @@ def _base_directory_behavior(value):
     return {"name": "baseDirectory", "options": {"value": value}}
 
 
-def test_extractOutboundPath_no_rewrite_behaviors(client):
+def test_extract_outbound_path_no_rewrite_behaviors(client):
     behaviors = [_origin_behavior()]
-    outboundPath, baseDir = client.extractOutboundPath(behaviors)
-    assert outboundPath is None
-    assert baseDir is None
+    outbound_path, base_dir = client.extractOutboundPath(behaviors)
+    assert outbound_path is None
+    assert base_dir is None
 
 
-def test_extractOutboundPath_rewriteUrl_replace(client):
+def test_extract_outbound_path_rewrite_url_replace(client):
     behaviors = [_rewrite_behavior("REPLACE", match="/legacy/", targetPath="/new/")]
-    outboundPath, baseDir = client.extractOutboundPath(behaviors)
-    assert outboundPath == "REPLACE:/legacy/→/new/"
-    assert baseDir is None
+    outbound_path, base_dir = client.extractOutboundPath(behaviors)
+    assert outbound_path == "REPLACE:/legacy/→/new/"
+    assert base_dir is None
 
 
-def test_extractOutboundPath_rewriteUrl_remove(client):
+def test_extract_outbound_path_rewrite_url_remove(client):
     behaviors = [_rewrite_behavior("REMOVE", match="/api/")]
-    outboundPath, _ = client.extractOutboundPath(behaviors)
-    assert outboundPath == "REMOVE:/api/"
+    outbound_path, _ = client.extractOutboundPath(behaviors)
+    assert outbound_path == "REMOVE:/api/"
 
 
-def test_extractOutboundPath_rewriteUrl_rewrite(client):
+def test_extract_outbound_path_rewrite_url_rewrite(client):
     behaviors = [_rewrite_behavior("REWRITE", targetUrl="/internal/page.html")]
-    outboundPath, _ = client.extractOutboundPath(behaviors)
-    assert outboundPath == "REWRITE:/internal/page.html"
+    outbound_path, _ = client.extractOutboundPath(behaviors)
+    assert outbound_path == "REWRITE:/internal/page.html"
 
 
-def test_extractOutboundPath_rewriteUrl_prepend(client):
+def test_extract_outbound_path_rewrite_url_prepend(client):
     behaviors = [_rewrite_behavior("PREPEND", targetPathPrepend="/v3")]
-    outboundPath, _ = client.extractOutboundPath(behaviors)
-    assert outboundPath == "PREPEND:/v3"
+    outbound_path, _ = client.extractOutboundPath(behaviors)
+    assert outbound_path == "PREPEND:/v3"
 
 
-def test_extractOutboundPath_rewriteUrl_regex_replace(client):
+def test_extract_outbound_path_rewrite_url_regex_replace(client):
     behaviors = [
         _rewrite_behavior(
             "REGEX_REPLACE", matchRegex="^/api/(.*)", targetRegex="/v3/api/$1"
         )
     ]
-    outboundPath, _ = client.extractOutboundPath(behaviors)
-    assert outboundPath == "REGEX:^/api/(.*)→/v3/api/$1"
+    outbound_path, _ = client.extractOutboundPath(behaviors)
+    assert outbound_path == "REGEX:^/api/(.*)→/v3/api/$1"
 
 
-def test_extractOutboundPath_baseDirectory(client):
+def test_extract_outbound_path_base_directory(client):
     behaviors = [_base_directory_behavior("/images/")]
-    outboundPath, baseDir = client.extractOutboundPath(behaviors)
-    assert outboundPath is None
-    assert baseDir == "/images/"
+    outbound_path, base_dir = client.extractOutboundPath(behaviors)
+    assert outbound_path is None
+    assert base_dir == "/images/"
 
 
-def test_extractOutboundPath_both_rewrite_and_basedir(client):
+def test_extract_outbound_path_both_rewrite_and_basedir(client):
     behaviors = [
         _rewrite_behavior("PREPEND", targetPathPrepend="/v3"),
         _base_directory_behavior("/static/"),
     ]
-    outboundPath, baseDir = client.extractOutboundPath(behaviors)
-    assert outboundPath == "PREPEND:/v3"
-    assert baseDir == "/static/"
+    outbound_path, base_dir = client.extractOutboundPath(behaviors)
+    assert outbound_path == "PREPEND:/v3"
+    assert base_dir == "/static/"
 
 
-def test_extractRuleRecords_outbound_path_on_record(client):
+def test_extract_rule_records_outbound_path_on_record(client):
     """rewriteUrl behavior is captured on the emitted record."""
     child = _make_rule(
         "v1",
@@ -625,8 +625,8 @@ def test_extractRuleRecords_outbound_path_on_record(client):
     assert records[0].baseDirectory is None
 
 
-def test_extractRuleRecords_outbound_path_inherited(client):
-    """Child without its own rewriteUrl inherits parent's outboundPath."""
+def test_extract_rule_records_outbound_path_inherited(client):
+    """Child without its own rewriteUrl inherits parent's outbound_path."""
     grandchild = _make_rule(
         "grandchild",
         criteria=[_path_criterion(["/v1/users/*"])],
@@ -652,7 +652,7 @@ def test_extractRuleRecords_outbound_path_inherited(client):
         assert r.outboundPath == "PREPEND:/internal"  # all carry it
 
 
-def test_extractRuleRecords_outbound_path_child_overrides(client):
+def test_extract_rule_records_outbound_path_child_overrides(client):
     """Child's own rewriteUrl overrides the inherited one."""
     child = _make_rule(
         "v1",

--- a/tests/akamai_utils/test_extract_rule_records.py
+++ b/tests/akamai_utils/test_extract_rule_records.py
@@ -6,13 +6,13 @@ Key invariants verified:
   3. Ancestor criteria are inherited (prepended) by child rules.
   4. hostnameCriteria is kept separate from pathCriteria.
   5. Negated criteria are prefixed with "!" in the list elements.
-  6. isPath flag (computed in the extractor) is True iff path-only, False otherwise.
+  6. Path eligibility is true iff path criteria exist and no cloudlet conditional exists.
   7. Security behaviors are mapped to normalized names.
+  8. rule_path is the JSON Pointer location of the rule in the tree.
 """
 
 import pytest
 
-from nodestream_akamai.akamai_utils.model import PropertyRuleRecord
 from nodestream_akamai.akamai_utils.property_client import (
     PATH_AND,
     AkamaiPropertyClient,
@@ -163,6 +163,7 @@ def test_extractRuleRecords_default_rule_only(client):
     assert r.pathCriteria == []
     assert r.hostnameCriteria == []
     assert r.originHostname == "backend.example.com"
+    assert r.rule_path == "/rules"
     assert r.ruleDepth == 0
     assert r.ruleName == "default"
 
@@ -185,6 +186,7 @@ def test_extractRuleRecords_single_child_path_rule(client):
     # root has no origin → omitted; only child emitted
     assert len(records) == 1
     child_record = records[0]
+    assert child_record.rule_path == "/rules/children/0"
     assert child_record.pathCriteria == ["/v1/*"]
     assert child_record.path == "/v1/*"
     assert child_record.ruleDepth == 1
@@ -241,6 +243,7 @@ def test_extractRuleRecords_criteria_inherited_from_ancestors(client):
     # One record: path = sorted AND-join of inherited + own criteria
     assert len(records) == 1
     r = records[0]
+    assert r.rule_path == "/rules/children/0/children/0"
     assert r.path == "/community/* AND /community/api/*"
     assert r.pathCriteria == ["/community/*", "/community/api/*"]
     assert r.ruleDepth == 2
@@ -306,6 +309,47 @@ def test_extractRuleRecords_mixed_path_hostname_is_path_eligible(client):
     # path+hostname → path-eligible → path is the positive glob
     assert r.path == "/v1/*"
     assert r.hostnameCriteria == ["api.example.com"]
+
+
+def test_extract_rule_records_duplicate_semantics_get_distinct_rule_paths(client):
+    first = _make_rule(
+        "Account Manager Cross Domain /app/unsubscribe Redirect ",
+        criteria=[_hostname_criterion(["*.intuit.com"], negative=True)],
+        behaviors=[_origin_behavior("first-backend.example.com")],
+    )
+    second = _make_rule(
+        "Account Manager Cross Domain /app/unsubscribe Redirect ",
+        criteria=[_hostname_criterion(["*.intuit.com"], negative=True)],
+        behaviors=[_origin_behavior("second-backend.example.com")],
+    )
+    root = _make_rule("default", children=[first, second])
+
+    records = client.extractRuleRecords(
+        rule=root, propertyId="501159", propertyName="p", version=1, deeplink=""
+    )
+
+    assert [r.rule_path for r in records] == [
+        "/rules/children/0",
+        "/rules/children/1",
+    ]
+    assert records[0].ruleName == records[1].ruleName
+    assert records[0].hostnameCriteria == records[1].hostnameCriteria
+
+
+def test_extract_rule_records_rule_path_keeps_skipped_child_indexes(client):
+    first = _make_rule("first", behaviors=[_origin_behavior("first.example.com")])
+    skipped = _make_rule("skipped-no-origin")
+    third = _make_rule("third", behaviors=[_origin_behavior("third.example.com")])
+    root = _make_rule("default", children=[first, skipped, third])
+
+    records = client.extractRuleRecords(
+        rule=root, propertyId="prp_skip", propertyName="p", version=1, deeplink=""
+    )
+
+    assert [r.rule_path for r in records] == [
+        "/rules/children/0",
+        "/rules/children/2",
+    ]
 
 
 # ── Security behaviors ─────────────────────────────────────────────────────────

--- a/tests/akamai_utils/test_property_client.py
+++ b/tests/akamai_utils/test_property_client.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from nodestream_akamai.akamai_utils import Origin
@@ -73,6 +75,13 @@ def test_searchRuleTreeForOrigins_simple(client):
     assert client.searchRuleTreeForOrigins(CRITERIA_RULE["rules"]) == {
         Origin(name="example.com")
     }
+
+
+def test_list_all_properties_propagates_hostname_errors(client):
+    client.listAccountHostnames = Mock(side_effect=RuntimeError("bad base url"))
+
+    with pytest.raises(RuntimeError, match="bad base url"):
+        client.list_all_properties()
 
 
 def test_searchRuleTreeForOrigins(client):

--- a/tests/akamai_utils/test_property_client.py
+++ b/tests/akamai_utils/test_property_client.py
@@ -8,6 +8,8 @@ from tests.akamai_utils.rulesdata import (
     rule_tree_643957,
 )
 
+# Test names mirror the legacy camelCase client methods they cover.
+
 CRITERIA_RULE = {
     "rules": {
         "name": "default",

--- a/tests/property_rule/test_property_rule.py
+++ b/tests/property_rule/test_property_rule.py
@@ -8,12 +8,10 @@ Covers all branches of extract_records:
   - successful extraction → pathKey and ruleKey set correctly
   - path-eligible rule (path set) → pathKey non-null
   - non-path rule (path None) → pathKey is None
-  - rule with hostname criteria → ruleKey.hostname set
-  - rule with no hostname criteria → ruleKey.hostname is None
+  - duplicate semantic rules → ruleKey differs by rule_path
 """
 
-import dataclasses
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from requests import HTTPError
@@ -62,6 +60,7 @@ def _make_record(
     origin_hostname="backend.example.com",
     rule_name="v1-api",
     rule_depth=1,
+    rule_path="/rules/children/0",
 ):
     return PropertyRuleRecord(
         path=path,
@@ -72,6 +71,7 @@ def _make_record(
         originType="CUSTOMER",
         outboundPath=None,
         baseDirectory=None,
+        rule_path=rule_path,
         ruleName=rule_name,
         ruleDepth=rule_depth,
         criteriaMustSatisfy="all",
@@ -147,9 +147,9 @@ async def test_extract_records_rule_tree_raises_continues():
 async def test_extract_records_path_eligible_rule():
     """A path-eligible record (path set) produces a non-null pathKey."""
     extractor = _make_extractor()
-    property = _make_property()
+    akamai_property = _make_property()
     record = _make_record(path="/v1/*", path_criteria=["/v1/*"])
-    extractor.client.list_all_properties = Mock(return_value=[property])
+    extractor.client.list_all_properties = Mock(return_value=[akamai_property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
     extractor.client.extractRuleRecords = Mock(return_value=[record])
 
@@ -158,20 +158,16 @@ async def test_extract_records_path_eligible_rule():
     assert len(results) == 1
     d = results[0]
     assert d["pathKey"] == {"proxy_id": "prp_123", "path": "/v1/*"}
-    assert d["ruleKey"] == {
-        "proxy_id": "prp_123",
-        "rule_name": "v1-api",
-        "hostname": None,
-    }
+    assert d["ruleKey"] == {"proxy_id": "prp_123", "rule_path": "/rules/children/0"}
 
 
 @pytest.mark.asyncio
 async def test_extract_records_non_path_rule_pathkey_none():
     """A non-path rule (path=None) produces pathKey=None."""
     extractor = _make_extractor()
-    property = _make_property()
+    akamai_property = _make_property()
     record = _make_record(path=None, path_criteria=[])
-    extractor.client.list_all_properties = Mock(return_value=[property])
+    extractor.client.list_all_properties = Mock(return_value=[akamai_property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
     extractor.client.extractRuleRecords = Mock(return_value=[record])
 
@@ -182,45 +178,59 @@ async def test_extract_records_non_path_rule_pathkey_none():
 
 
 @pytest.mark.asyncio
-async def test_extract_records_rulekey_includes_hostname():
-    """ruleKey.hostname is the first hostnameCriteria value when present."""
+async def test_extract_records_rulekey_ignores_hostname_criteria():
+    """ruleKey uses rule_path, not hostname criteria."""
     extractor = _make_extractor()
-    property = _make_property()
+    akamai_property = _make_property()
     record = _make_record(
         path="/v1/*",
         hostname_criteria=["api.example.com", "api2.example.com"],
     )
-    extractor.client.list_all_properties = Mock(return_value=[property])
+    extractor.client.list_all_properties = Mock(return_value=[akamai_property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
     extractor.client.extractRuleRecords = Mock(return_value=[record])
 
     results = [x async for x in extractor.extract_records()]
 
-    assert results[0]["ruleKey"]["hostname"] == "api.example.com"
+    assert results[0]["ruleKey"] == {
+        "proxy_id": "prp_123",
+        "rule_path": "/rules/children/0",
+    }
 
 
 @pytest.mark.asyncio
-async def test_extract_records_rulekey_hostname_none_when_no_criteria():
-    """ruleKey.hostname is None when hostnameCriteria is empty."""
+async def test_extract_records_rulekey_excludes_rule_name_and_hostname():
+    """Semantic fields remain metadata, not identity."""
     extractor = _make_extractor()
-    property = _make_property()
+    akamai_property = _make_property()
     record = _make_record(path=None, hostname_criteria=[])
-    extractor.client.list_all_properties = Mock(return_value=[property])
+    extractor.client.list_all_properties = Mock(return_value=[akamai_property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
     extractor.client.extractRuleRecords = Mock(return_value=[record])
 
     results = [x async for x in extractor.extract_records()]
 
-    assert results[0]["ruleKey"]["hostname"] is None
+    assert "rule_name" not in results[0]["ruleKey"]
+    assert "hostname" not in results[0]["ruleKey"]
+
+
+def test_build_rulekey_distinguishes_duplicate_semantics_by_rule_path():
+    extractor = _make_extractor()
+    first = {"propertyId": "501159", "rule_path": "/rules/children/0"}
+    second = {"propertyId": "501159", "rule_path": "/rules/children/1"}
+
+    assert extractor.buildRuleKey(first) != extractor.buildRuleKey(second)
 
 
 @pytest.mark.asyncio
 async def test_extract_records_deeplink_constructed_correctly():
     """deeplink is built from assetId, version, and groupId."""
     extractor = _make_extractor()
-    property = _make_property(asset_id="99999", production_version=7, group_id="grp_42")
+    akamai_property = _make_property(
+        asset_id="99999", production_version=7, group_id="grp_42"
+    )
     record = _make_record()
-    extractor.client.list_all_properties = Mock(return_value=[property])
+    extractor.client.list_all_properties = Mock(return_value=[akamai_property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
 
     captured_deeplink = {}
@@ -243,12 +253,12 @@ async def test_extract_records_deeplink_constructed_correctly():
 async def test_extract_records_multiple_records_from_one_property():
     """Multiple rule records from a single property are all yielded."""
     extractor = _make_extractor()
-    property = _make_property()
+    akamai_property = _make_property()
     records = [
         _make_record(path="/v1/*", rule_name="v1"),
         _make_record(path=None, rule_name="default", rule_depth=0),
     ]
-    extractor.client.list_all_properties = Mock(return_value=[property])
+    extractor.client.list_all_properties = Mock(return_value=[akamai_property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
     extractor.client.extractRuleRecords = Mock(return_value=records)
 

--- a/tests/property_rule/test_property_rule.py
+++ b/tests/property_rule/test_property_rule.py
@@ -71,7 +71,7 @@ def _make_record(
         originType="CUSTOMER",
         outboundPath=None,
         baseDirectory=None,
-        rule_path=rule_path,
+        rulePath=rule_path,
         ruleName=rule_name,
         ruleDepth=rule_depth,
         criteriaMustSatisfy="all",
@@ -158,6 +158,8 @@ async def test_extract_records_path_eligible_rule():
     assert len(results) == 1
     d = results[0]
     assert d["pathKey"] == {"proxy_id": "prp_123", "path": "/v1/*"}
+    assert d["rulePath"] == "/rules/children/0"
+    assert "rule_path" not in d
     assert d["ruleKey"] == {"proxy_id": "prp_123", "rule_path": "/rules/children/0"}
 
 
@@ -216,10 +218,10 @@ async def test_extract_records_rulekey_excludes_rule_name_and_hostname():
 
 def test_build_rulekey_distinguishes_duplicate_semantics_by_rule_path():
     extractor = _make_extractor()
-    first = {"propertyId": "501159", "rule_path": "/rules/children/0"}
-    second = {"propertyId": "501159", "rule_path": "/rules/children/1"}
+    first = {"propertyId": "501159", "rulePath": "/rules/children/0"}
+    second = {"propertyId": "501159", "rulePath": "/rules/children/1"}
 
-    assert extractor.buildRuleKey(first) != extractor.buildRuleKey(second)
+    assert extractor.build_rule_key(first) != extractor.build_rule_key(second)
 
 
 @pytest.mark.asyncio

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -20,16 +20,16 @@ def extractor():
 
 
 def _make_prop(**kwargs):
-    defaults = dict(
-        propertyId="prp_1234",
-        propertyName="test-name",
-        productionVersion=1,
-        stagingVersion=None,
-        assetId="aid_1",
-        contractId="ctr_1",
-        groupId="grp_1",
-        hostnames=[],
-    )
+    defaults = {
+        "propertyId": "prp_1234",
+        "propertyName": "test-name",
+        "productionVersion": 1,
+        "stagingVersion": None,
+        "assetId": "aid_1",
+        "contractId": "ctr_1",
+        "groupId": "grp_1",
+        "hostnames": [],
+    }
     defaults.update(kwargs)
     return AkamaiPropertyResponse(**defaults)
 
@@ -46,7 +46,9 @@ async def test_extract_records_fail_other(extractor):
     extractor.client.list_all_properties = Mock(
         return_value=[
             None,
-            _make_prop(productionVersion=1, propertyName="test-name", propertyId="1234"),
+            _make_prop(
+                productionVersion=1, propertyName="test-name", propertyId="1234"
+            ),
         ]
     )
     extractor.client.describePropertyByDict = Mock(side_effect=KeyError)

--- a/tests/test_staging_property.py
+++ b/tests/test_staging_property.py
@@ -4,7 +4,10 @@ import pytest
 from requests import HTTPError
 
 from nodestream_akamai import AkamaiStagingPropertyExtractor
-from nodestream_akamai.akamai_utils.model import AkamaiPropertyResponse, PropertyDescription
+from nodestream_akamai.akamai_utils.model import (
+    AkamaiPropertyResponse,
+    PropertyDescription,
+)
 
 
 @pytest.fixture
@@ -20,16 +23,16 @@ def extractor():
 
 
 def _make_prop(**kwargs):
-    defaults = dict(
-        propertyId="prp_123",
-        propertyName="test-property",
-        productionVersion=None,
-        stagingVersion=42,
-        assetId="aid_123",
-        contractId="ctr_123",
-        groupId="grp_123",
-        hostnames=[],
-    )
+    defaults = {
+        "propertyId": "prp_123",
+        "propertyName": "test-property",
+        "productionVersion": None,
+        "stagingVersion": 42,
+        "assetId": "aid_123",
+        "contractId": "ctr_123",
+        "groupId": "grp_123",
+        "hostnames": [],
+    }
     defaults.update(kwargs)
     return AkamaiPropertyResponse(**defaults)
 
@@ -58,7 +61,9 @@ async def test_extract_records_fail_other(extractor):
 
 @pytest.mark.asyncio
 async def test_extract_records_success(extractor):
-    mock_prop = _make_prop(stagingVersion=42, propertyName="test-property", propertyId="prp_123")
+    mock_prop = _make_prop(
+        stagingVersion=42, propertyName="test-property", propertyId="prp_123"
+    )
 
     mock_description = PropertyDescription(
         id="prp_123",


### PR DESCRIPTION
## Summary

Property rule ingestion no longer treats repeated Akamai rule names and hostname criteria as duplicate graph nodes. Each AkamaiPropertyRule is keyed by its structural rule path within the property tree, while the emitted extractor record keeps the existing API-shaped `rulePath` field so downstream JSON consumers do not see a field-name change.

The pipeline now maps `rulePath` into graph property `rule_path`, and the derived `ruleKey.rule_path` is used consistently for rule relationships. Ruff naming exceptions are centralized for the Akamai/PAPI-shaped boundary files, with file-local notes so future edits do not accidentally rename emitted fields.

## Test Plan

- `.venv/bin/ruff check --output-format=concise`
- `.venv/bin/black --check .`
- `.venv/bin/isort --check-only .`
- `.venv/bin/python -m pytest -q -o log_cli=false` (`81 passed`)
- `git diff --check`