### PR TITLE
fix(property-rule): key AkamaiPropertyRule on (proxy_id, rule_path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,34 @@ targets:
 1. Verify nodestream has loaded the pipelines: `poetry run nodestream show`
 1. Use nodestream to run the pipelines: `poetry run nodestream run <pipeline-name> --target my-db`
 
+# Property rule pipeline: AkamaiPropertyRule keying
+
+As of 0.16.2 the `property-rule` pipeline keys `AkamaiPropertyRule` nodes on the
+rule's position in the Akamai rule tree: `(proxy_id, rule_path)`, where
+`rule_path` is the ordinal index path from the root (`ROOT`, `3.0`, `3.0.1`, …).
+The rule's human-readable name breadcrumb is stored as the `full_path` property.
+
+Previously these nodes were keyed on `(proxy_id, rule_name, hostname)`, which is
+not unique — Akamai rule names repeat across a property's tree and most rules
+have no hostname criterion — so the NODE KEY constraint could not be created
+(`Neo.DatabaseError.Schema.ConstraintCreationFailed`). A path-eligible rule is
+also now written as a `Path` node **only** (never both a `Path` and an
+`AkamaiPropertyRule`).
+
+If a database was loaded by an older plugin version that used the old key, do
+**not** just rerun the pipeline: the old nodes have no `rule_path`, so a rerun
+creates a parallel set of correctly-keyed nodes and leaves the old ones behind.
+Instead, drop the plugin-owned `AkamaiPropertyRule` subgraph, (re)create the
+constraint, then rerun the pipeline so nodes repopulate under the new key.
+
+Find databases that still hold old property-rule nodes:
+
+```cypher
+MATCH (r:AkamaiPropertyRule)
+WHERE r.rule_path IS NULL
+RETURN count(r) AS old_rule_nodes
+```
+
 # Using make
 1. Install make (ie. `brew install make`)
 1. Run `make run`

--- a/nodestream_akamai/akamai_utils/model.py
+++ b/nodestream_akamai/akamai_utils/model.py
@@ -161,9 +161,11 @@ class PropertyRuleRecord:
     # repeats across the tree and must NOT be a key part.
     rulePath: str
     # Human-readable breadcrumb of rule names from root to this rule, e.g.
-    # "default/Origin mappings/qal/origin - leadgen". NOTE: unlike rulePath this
-    # is name-based and can collide when sibling rules share a name, so it is
-    # carried as a queryable node property only, never as a key.
+    # "default/Origin mappings/qal/origin - leadgen". Rule names are free text
+    # and may contain "/", so each name segment has "/" replaced with "_" here
+    # to keep the "/" level-separator unambiguous (rule_name keeps the raw name).
+    # NOTE: unlike rulePath this is name-based and can collide when sibling rules
+    # share a name, so it is a queryable node property only, never a key.
     fullPath: str
     criteriaMustSatisfy: str  # "all" | "any"
     securityBehaviors: List[str]  # e.g. ["AKAMAI_EDGE_AUTH"]

--- a/nodestream_akamai/akamai_utils/model.py
+++ b/nodestream_akamai/akamai_utils/model.py
@@ -152,6 +152,16 @@ class PropertyRuleRecord:
     # Rule metadata
     ruleName: str
     ruleDepth: int  # 0 = default/root rule
+    # Stable tree-position identity. rulePath is the ordinal index path from the
+    # root ("ROOT" for the default rule, "3.0", "3.0.1", ...). It is unique by
+    # construction — a rule tree is an ordered array, so no two rules share a
+    # position — and is what the AkamaiPropertyRule node is keyed on. rule_name
+    # is a human label that repeats across the tree and must NOT be a key part.
+    rulePath: str
+    # Human-readable breadcrumb of rule names from root to this rule, e.g.
+    # "default/Origin mappings/qal/martech-qal.intuit.com origin - leadgen".
+    # Carried as a queryable node property (not a key).
+    fullPath: str
     criteriaMustSatisfy: str  # "all" | "any"
     securityBehaviors: List[str]  # e.g. ["AKAMAI_EDGE_AUTH"]
 

--- a/nodestream_akamai/akamai_utils/model.py
+++ b/nodestream_akamai/akamai_utils/model.py
@@ -152,15 +152,18 @@ class PropertyRuleRecord:
     # Rule metadata
     ruleName: str
     ruleDepth: int  # 0 = default/root rule
-    # Stable tree-position identity. rulePath is the ordinal index path from the
-    # root ("ROOT" for the default rule, "3.0", "3.0.1", ...). It is unique by
-    # construction — a rule tree is an ordered array, so no two rules share a
-    # position — and is what the AkamaiPropertyRule node is keyed on. rule_name
-    # is a human label that repeats across the tree and must NOT be a key part.
+    # Stable tree-position identity. rulePath is the rule's JSON Pointer
+    # (RFC 6901) position in the rule tree: "/rules" for the default rule,
+    # "/rules/children/0", "/rules/children/0/children/2", ... It is unique by
+    # construction — it is index-based (not name-based), so no two rules share a
+    # position — navigable back into the raw rule-tree JSON, and is what the
+    # AkamaiPropertyRule node is keyed on. rule_name is a human label that
+    # repeats across the tree and must NOT be a key part.
     rulePath: str
     # Human-readable breadcrumb of rule names from root to this rule, e.g.
-    # "default/Origin mappings/qal/martech-qal.intuit.com origin - leadgen".
-    # Carried as a queryable node property (not a key).
+    # "default/Origin mappings/qal/origin - leadgen". NOTE: unlike rulePath this
+    # is name-based and can collide when sibling rules share a name, so it is
+    # carried as a queryable node property only, never as a key.
     fullPath: str
     criteriaMustSatisfy: str  # "all" | "any"
     securityBehaviors: List[str]  # e.g. ["AKAMAI_EDGE_AUTH"]

--- a/nodestream_akamai/akamai_utils/property_client.py
+++ b/nodestream_akamai/akamai_utils/property_client.py
@@ -688,6 +688,8 @@ class AkamaiPropertyClient(AkamaiApiClient):
         version: int,
         deeplink: str,
         depth: int = 0,
+        rulePath: str = "ROOT",
+        fullPath: str | None = None,
         inheritedPathCriteria: list | None = None,
         inheritedHostnameCriteria: list | None = None,
         inheritedOriginHostname: str | None = None,
@@ -739,6 +741,7 @@ class AkamaiPropertyClient(AkamaiApiClient):
         )
 
         ruleName = rule.get("name", "default")
+        thisFullPath = fullPath if fullPath is not None else ruleName
 
         isPathEligible = bool(combinedPathCriteria) and conditionalOriginId is None
         canonicalPath = (
@@ -761,6 +764,8 @@ class AkamaiPropertyClient(AkamaiApiClient):
                     baseDirectory=baseDirectory,
                     ruleName=ruleName,
                     ruleDepth=depth,
+                    rulePath=rulePath,
+                    fullPath=thisFullPath,
                     criteriaMustSatisfy=rule.get("criteriaMustSatisfy", "all"),
                     securityBehaviors=securityBehaviors,
                     propertyId=propertyId,
@@ -770,7 +775,16 @@ class AkamaiPropertyClient(AkamaiApiClient):
                 )
             )
 
-        for childRule in rule.get("children", []):
+        for childIndex, childRule in enumerate(rule.get("children", [])):
+            # rulePath is the ordinal index path: root is "ROOT", its children are
+            # "0", "1", ...; grandchildren "0.0", "0.1", ... This is unique per
+            # rule regardless of names, and stable across ingests for a given
+            # property version.
+            childRulePath = (
+                str(childIndex) if rulePath == "ROOT" else f"{rulePath}.{childIndex}"
+            )
+            childName = childRule.get("name", "default")
+            childFullPath = f"{thisFullPath}/{childName}"
             records.extend(
                 self.extractRuleRecords(
                     rule=childRule,
@@ -779,6 +793,8 @@ class AkamaiPropertyClient(AkamaiApiClient):
                     version=version,
                     deeplink=deeplink,
                     depth=depth + 1,
+                    rulePath=childRulePath,
+                    fullPath=childFullPath,
                     inheritedPathCriteria=combinedPathCriteria,
                     inheritedHostnameCriteria=combinedHostnameCriteria,
                     inheritedOriginHostname=originHostname,

--- a/nodestream_akamai/akamai_utils/property_client.py
+++ b/nodestream_akamai/akamai_utils/property_client.py
@@ -688,7 +688,7 @@ class AkamaiPropertyClient(AkamaiApiClient):
         version: int,
         deeplink: str,
         depth: int = 0,
-        rulePath: str = "ROOT",
+        rulePath: str = "/rules",
         fullPath: str | None = None,
         inheritedPathCriteria: list | None = None,
         inheritedHostnameCriteria: list | None = None,
@@ -776,13 +776,13 @@ class AkamaiPropertyClient(AkamaiApiClient):
             )
 
         for childIndex, childRule in enumerate(rule.get("children", [])):
-            # rulePath is the ordinal index path: root is "ROOT", its children are
-            # "0", "1", ...; grandchildren "0.0", "0.1", ... This is unique per
-            # rule regardless of names, and stable across ingests for a given
-            # property version.
-            childRulePath = (
-                str(childIndex) if rulePath == "ROOT" else f"{rulePath}.{childIndex}"
-            )
+            # rulePath is the rule's JSON Pointer (RFC 6901) position in the rule
+            # tree: root is "/rules", its children are "/rules/children/0", ...;
+            # grandchildren "/rules/children/0/children/2". It is unique per rule
+            # regardless of names (it is index-based, not name-based), navigable
+            # back into the raw rule-tree JSON, and stable across ingests for a
+            # given property version.
+            childRulePath = f"{rulePath}/children/{childIndex}"
             childName = childRule.get("name", "default")
             childFullPath = f"{thisFullPath}/{childName}"
             records.extend(

--- a/nodestream_akamai/akamai_utils/property_client.py
+++ b/nodestream_akamai/akamai_utils/property_client.py
@@ -1,7 +1,7 @@
 import itertools
 import logging
 import re
-from typing import Any, List, Tuple
+from typing import Any, ClassVar, List, Tuple
 
 from jsonpath_ng.ext import parse
 
@@ -551,7 +551,7 @@ class AkamaiPropertyClient(AkamaiApiClient):
 
     # ── Rule-level extraction (Proxy schema) ──────────────────────────
 
-    SECURITY_BEHAVIOR_MAP = {
+    SECURITY_BEHAVIOR_MAP: ClassVar[dict[str, str]] = {
         "edgeAuth": "AKAMAI_EDGE_AUTH",
         "tokenAuth": "AKAMAI_TOKEN_AUTH",
         "siteShield": "AKAMAI_SITE_SHIELD",

--- a/nodestream_akamai/akamai_utils/property_client.py
+++ b/nodestream_akamai/akamai_utils/property_client.py
@@ -16,6 +16,18 @@ from .model import (
 
 PATH_AND = " AND "
 
+# full_path joins rule names with "/", but Akamai rule names are free text and
+# may themselves contain "/". Replace "/" with "_" in each name segment ONLY when
+# building the human-readable full_path property, so the separator is unambiguous.
+# This does NOT affect rule_path (the key), rule_name, or any other field.
+FULL_PATH_SEPARATOR = "/"
+
+
+def sanitize_full_path_segment(name: str) -> str:
+    """Replace the full_path separator inside a single rule-name segment."""
+    return name.replace(FULL_PATH_SEPARATOR, "_")
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -741,7 +753,11 @@ class AkamaiPropertyClient(AkamaiApiClient):
         )
 
         ruleName = rule.get("name", "default")
-        thisFullPath = fullPath if fullPath is not None else ruleName
+        # full_path only: sanitize "/" in the name so the separator is unambiguous.
+        # rule_name (below) keeps the raw Akamai name.
+        thisFullPath = (
+            fullPath if fullPath is not None else sanitize_full_path_segment(ruleName)
+        )
 
         isPathEligible = bool(combinedPathCriteria) and conditionalOriginId is None
         canonicalPath = (
@@ -784,7 +800,8 @@ class AkamaiPropertyClient(AkamaiApiClient):
             # given property version.
             childRulePath = f"{rulePath}/children/{childIndex}"
             childName = childRule.get("name", "default")
-            childFullPath = f"{thisFullPath}/{childName}"
+            # full_path only: sanitize "/" in the child name segment.
+            childFullPath = f"{thisFullPath}/{sanitize_full_path_segment(childName)}"
             records.extend(
                 self.extractRuleRecords(
                     rule=childRule,

--- a/nodestream_akamai/property-rule.yaml
+++ b/nodestream_akamai/property-rule.yaml
@@ -1,20 +1,25 @@
 # AkamaiProperty Proxy schema — rule-level pipeline
 #
-# Records are split into two node types based on criteria dimensionality:
+# Each rule becomes EXACTLY ONE node (Path XOR AkamaiPropertyRule):
 #
-#   Path-only rules (pathCriteria non-empty, no hostname, no cloudlet):
+#   Path-eligible rules (pathCriteria non-empty, no cloudlet conditional):
 #     (AkamaiProperty:Proxy)-[:HAS_PATH]->(Path)-[:ROUTES_TO]->(Endpoint)
-#     — identical key schema to IAGE: (proxy_id, path)
-#     — pathCriteria list is directly micromatch-compatible
+#     — keyed (proxy_id, path); pathCriteria is micromatch-compatible
 #
-#   All other rules (hostname-dimensional, cloudlet-conditional, catch-all):
+#   All other rules (hostname-only, cloudlet-conditional, catch-all, behaviour):
 #     (AkamaiProperty:Proxy)-[:HAS_RULE]->(AkamaiPropertyRule)-[:ROUTES_TO]->(Endpoint)
-#     — keyed on (proxy_id, rule_name) since path may be absent
+#     — keyed (proxy_id, rule_path)
 #
-# The null-key-drop behaviour of the nodestream interpreter is the guard:
-# passes that target Path use isPath=true records; passes targeting
-# AkamaiPropertyRule use isPath=false records. Records with null keys
-# are silently skipped, so each pass only writes what it owns.
+# rule_path is the rule's ordinal tree position ("ROOT", "3.0", "3.0.1", ...).
+# It is unique by construction (a rule tree is an ordered array), so it can back
+# a NODE KEY constraint. rule_name is a human label that repeats across a tree
+# and hostname is null for most rules, so (proxy_id, rule_name, hostname) is NOT
+# unique — it caused ConstraintCreationFailed. full_path (the name breadcrumb) is
+# carried as a readable property for querying.
+#
+# Path XOR Rule: the extractor sets pathKey XOR ruleKey per record (never both),
+# so each rule is written by exactly one pass. The interpreter drops null-key
+# records, so each pass only writes the records it owns.
 
 - implementation: nodestream_akamai.property_rule:AkamaiPropertyRuleExtractor
   arguments:
@@ -90,10 +95,10 @@
           do_remove_trailing_dots: true
         node_key:
           proxy_id: !jmespath 'ruleKey.proxy_id'
-          rule_name: !jmespath 'ruleKey.rule_name'
-          hostname: !jmespath 'ruleKey.hostname'
+          rule_path: !jmespath 'ruleKey.rule_path'
         node_properties:
           rule_name: !jmespath 'ruleName'
+          full_path: !jmespath 'fullPath'
           rule_depth: !jmespath 'ruleDepth'
           path_criteria: !jmespath 'pathCriteria'
           hostname_criteria: !jmespath 'hostnameCriteria'
@@ -131,8 +136,7 @@
           do_remove_trailing_dots: true
         key:
           proxy_id: !jmespath 'ruleKey.proxy_id'
-          rule_name: !jmespath 'ruleKey.rule_name'
-          hostname: !jmespath 'ruleKey.hostname'
+          rule_path: !jmespath 'ruleKey.rule_path'
       - type: relationship
         node_type: Endpoint
         relationship_type: ROUTES_TO
@@ -170,8 +174,7 @@
           do_remove_trailing_dots: true
         key:
           proxy_id: !jmespath 'ruleKey.proxy_id'
-          rule_name: !jmespath 'ruleKey.rule_name'
-          hostname: !jmespath 'ruleKey.hostname'
+          rule_path: !jmespath 'ruleKey.rule_path'
       - type: relationship
         node_type: AuthenticationPolicy
         relationship_type: USES_AUTHENTICATION_BEHAVIOR

--- a/nodestream_akamai/property-rule.yaml
+++ b/nodestream_akamai/property-rule.yaml
@@ -10,7 +10,8 @@
 #     (AkamaiProperty:Proxy)-[:HAS_RULE]->(AkamaiPropertyRule)-[:ROUTES_TO]->(Endpoint)
 #     — keyed (proxy_id, rule_path)
 #
-# rule_path is the rule's ordinal tree position ("ROOT", "3.0", "3.0.1", ...).
+# rule_path is the rule's JSON Pointer tree position ("/rules",
+# "/rules/children/0", "/rules/children/0/children/2", ...).
 # It is unique by construction (a rule tree is an ordered array), so it can back
 # a NODE KEY constraint. rule_name is a human label that repeats across a tree
 # and hostname is null for most rules, so (proxy_id, rule_name, hostname) is NOT

--- a/nodestream_akamai/property_rule/property_rule.py
+++ b/nodestream_akamai/property_rule/property_rule.py
@@ -31,26 +31,33 @@ class AkamaiPropertyRuleExtractor(Extractor):
 
         pathKey is non-null iff path is set (path-eligible rule). The path
         value is the canonical sorted AND-joined criteria string produced by
-        extractRuleRecords.
+        extractRuleRecords. A path-eligible rule becomes a Path node ONLY —
+        buildRuleKey returns None for it (Path XOR Rule).
         """
         if record["path"] is None:
             return None
         return {"proxy_id": record["propertyId"], "path": record["path"]}
 
-    def buildRuleKey(self, record: dict) -> dict:
-        """Return the ruleKey dict for an AkamaiPropertyRule node.
+    def buildRuleKey(self, record: dict) -> dict | None:
+        """Return the ruleKey dict for an AkamaiPropertyRule node, or None.
 
-        hostname is included so that two rules with the same name but different
-        hostname criteria produce distinct AkamaiPropertyRule nodes. It is None
-        for rules with no hostname dimension.
+        Keyed on (proxy_id, rule_path) — the rule's ordinal tree position — which
+        is unique by construction. rule_name is a human label that repeats across
+        a property's rule tree (many rules are named "US", "default", etc.), and
+        hostname is null for the majority of rules (those not under a hostname
+        section), so (proxy_id, rule_name, hostname) is NOT unique and cannot back
+        a NODE KEY constraint. rule_path always can.
+
+        Returns None for path-eligible rules so that each rule is EITHER a Path
+        node OR an AkamaiPropertyRule, never both (Path XOR Rule). Previously
+        ruleKey was always built, so every path-bearing rule was written as both
+        a Path and an AkamaiPropertyRule.
         """
-        firstHostname = (
-            record["hostnameCriteria"][0] if record["hostnameCriteria"] else None
-        )
+        if record["path"] is not None:
+            return None
         return {
             "proxy_id": record["propertyId"],
-            "rule_name": record["ruleName"],
-            "hostname": firstHostname,
+            "rule_path": record["rulePath"],
         }
 
     async def extractRecordsForProperty(self, property: AkamaiPropertyResponse):

--- a/nodestream_akamai/property_rule/property_rule.py
+++ b/nodestream_akamai/property_rule/property_rule.py
@@ -22,31 +22,31 @@ class AkamaiPropertyRuleExtractor(Extractor):
     record with path=None — Rule node only, no Path node.
     """
 
-    def __init__(self, **akamaiClientKwargs) -> None:
-        self.client = AkamaiPropertyClient(**akamaiClientKwargs)
+    def __init__(self, **akamai_client_kwargs) -> None:
+        self.client = AkamaiPropertyClient(**akamai_client_kwargs)
         self.logger = logging.getLogger(self.__class__.__name__)
 
-    def buildPathKey(self, record: dict) -> dict | None:
+    def build_path_key(self, record: dict) -> dict | None:
         """Return the pathKey dict for a path-eligible rule, or None.
 
         pathKey is non-null iff path is set (path-eligible rule). The path
         value is the canonical sorted AND-joined criteria string produced by
         extractRuleRecords. A path-eligible rule becomes a Path node ONLY —
-        buildRuleKey returns None for it (Path XOR Rule).
+        build_rule_key returns None for it (Path XOR Rule).
         """
         if record["path"] is None:
             return None
         return {"proxy_id": record["propertyId"], "path": record["path"]}
 
-    def buildRuleKey(self, record: dict) -> dict | None:
+    def build_rule_key(self, record: dict) -> dict | None:
         """Return the ruleKey dict for an AkamaiPropertyRule node, or None.
 
-        Keyed on (proxy_id, rule_path) — the rule's JSON Pointer tree position — which
-        is unique by construction. rule_name is a human label that repeats across
-        a property's rule tree (many rules are named "US", "default", etc.), and
-        hostname is null for the majority of rules (those not under a hostname
-        section), so (proxy_id, rule_name, hostname) is NOT unique and cannot back
-        a NODE KEY constraint. rule_path always can.
+        Keyed on (proxy_id, rule_path) — the rule's JSON Pointer tree position —
+        which is unique by construction. rule_name is a human label that repeats
+        across a property's rule tree (many rules are named "US", "default",
+        etc.), and hostname is null for the majority of rules (those not under a
+        hostname section), so (proxy_id, rule_name, hostname) is NOT unique and
+        cannot back a NODE KEY constraint. rule_path always can.
 
         Returns None for path-eligible rules so that each rule is EITHER a Path
         node OR an AkamaiPropertyRule, never both (Path XOR Rule). Previously
@@ -60,30 +60,32 @@ class AkamaiPropertyRuleExtractor(Extractor):
             "rule_path": record["rulePath"],
         }
 
-    async def extractRecordsForProperty(self, property: AkamaiPropertyResponse):
+    async def extract_records_for_property(
+        self, akamai_property: AkamaiPropertyResponse
+    ):
         """Yield pipeline dicts for every rule record in one property."""
         self.logger.info(
             "extracting rule records for property %s (id=%s)",
-            property.propertyName,
-            property.propertyId,
+            akamai_property.propertyName,
+            akamai_property.propertyId,
         )
-        ruleTree = self.client.get_rule_tree(
-            property_id=property.propertyId,
-            version=property.productionVersion,
-            contract_id=property.contractId,
-            group_id=property.groupId,
+        rule_tree = self.client.get_rule_tree(
+            property_id=akamai_property.propertyId,
+            version=akamai_property.productionVersion,
+            contract_id=akamai_property.contractId,
+            group_id=akamai_property.groupId,
         )
-        for ruleRecord in self.client.extractRuleRecords(
-            rule=ruleTree["rules"],
-            propertyId=property.propertyId,
-            propertyName=property.propertyName,
-            version=property.productionVersion,
-            deeplink=property.deeplink,
+        for rule_record in self.client.extractRuleRecords(
+            rule=rule_tree["rules"],
+            propertyId=akamai_property.propertyId,
+            propertyName=akamai_property.propertyName,
+            version=akamai_property.productionVersion,
+            deeplink=akamai_property.deeplink,
         ):
-            recordDict = dataclasses.asdict(ruleRecord)
-            recordDict["pathKey"] = self.buildPathKey(recordDict)
-            recordDict["ruleKey"] = self.buildRuleKey(recordDict)
-            yield recordDict
+            record_dict = dataclasses.asdict(rule_record)
+            record_dict["pathKey"] = self.build_path_key(record_dict)
+            record_dict["ruleKey"] = self.build_rule_key(record_dict)
+            yield record_dict
 
     async def extract_records(self):
         self.logger.debug("extracting property rule records")
@@ -93,15 +95,17 @@ class AkamaiPropertyRuleExtractor(Extractor):
             self.logger.exception("Failed to list properties: %s", err)
             raise
 
-        for property in properties or []:
-            if property is None or property.productionVersion is None:
+        for akamai_property in properties or []:
+            if akamai_property is None or akamai_property.productionVersion is None:
                 continue
             try:
-                async for recordDict in self.extractRecordsForProperty(property):
-                    yield recordDict
+                async for record_dict in self.extract_records_for_property(
+                    akamai_property
+                ):
+                    yield record_dict
             except Exception:
                 self.logger.exception(
                     "Failed to extract rule records for property %s (id=%s)",
-                    property.propertyName,
-                    property.propertyId,
+                    akamai_property.propertyName,
+                    akamai_property.propertyId,
                 )

--- a/nodestream_akamai/property_rule/property_rule.py
+++ b/nodestream_akamai/property_rule/property_rule.py
@@ -41,7 +41,7 @@ class AkamaiPropertyRuleExtractor(Extractor):
     def buildRuleKey(self, record: dict) -> dict | None:
         """Return the ruleKey dict for an AkamaiPropertyRule node, or None.
 
-        Keyed on (proxy_id, rule_path) — the rule's ordinal tree position — which
+        Keyed on (proxy_id, rule_path) — the rule's JSON Pointer tree position — which
         is unique by construction. rule_name is a human label that repeats across
         a property's rule tree (many rules are named "US", "default", etc.), and
         hostname is null for the majority of rules (those not under a hostname

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nodestream-plugin-akamai"
-version = "0.16.1"
+version = "0.16.2"
 description = "Pipeline Plugin for Akamai Data"
 authors = [
 "Zach Probst <Zach_Probst@intuit.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,12 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [ "S101", "S106" ]
+# Akamai/PAPI-facing records keep API-shaped names; pipeline YAML maps them to
+# graph snake_case properties.
+"nodestream_akamai/akamai_utils/model.py" = [ "N802", "N815" ]
+"nodestream_akamai/akamai_utils/property_client.py" = [ "N802", "N803", "N806" ]
+# These tests mirror legacy camelCase client method names.
+"tests/akamai_utils/test_property_client.py" = [ "N802" ]
 
 
 [build-system]

--- a/tests/property_rule/fixtures/collision_repro.json
+++ b/tests/property_rule/fixtures/collision_repro.json
@@ -1,0 +1,54 @@
+{
+    "accountId": "act_TEST",
+    "contractId": "ctr_TEST",
+    "groupId": "grp_TEST",
+    "ruleFormat": "latest",
+    "propertyId": "prp_collision",
+    "propertyName": "collision_repro",
+    "propertyVersion": 1,
+    "rules": {
+        "name": "default",
+        "children": [
+            {
+                "name": "Prod",
+                "children": [
+                    {
+                        "name": "US",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "origin", "options": { "originType": "CUSTOMER", "hostname": "prod-us.example.com" } }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all"
+                    }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all"
+            },
+            {
+                "name": "Pre-Prod",
+                "children": [
+                    {
+                        "name": "US",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "origin", "options": { "originType": "CUSTOMER", "hostname": "preprod-us.example.com" } }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all"
+                    }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all"
+            }
+        ],
+        "behaviors": [
+            { "name": "origin", "options": { "originType": "CUSTOMER", "hostname": "root.example.com" } }
+        ],
+        "criteria": [],
+        "criteriaMustSatisfy": "all",
+        "comments": "Minimal repro: two rules named 'US' at different tree positions, no path, no hostname. The OLD key (proxy_id, rule_name, hostname) makes them collide; the NEW key (proxy_id, rule_path) keeps them distinct."
+    }
+}

--- a/tests/property_rule/fixtures/leadgencapability_pm.v21.json
+++ b/tests/property_rule/fixtures/leadgencapability_pm.v21.json
@@ -1,0 +1,314 @@
+{
+    "accountId": "act_1-17WC",
+    "contractId": "ctr_C-19XSR8V",
+    "groupId": "grp_59340",
+    "ruleFormat": "latest",
+    "propertyId": "prp_1317086",
+    "propertyName": "leadgencapability_pm",
+    "propertyVersion": 21,
+    "rules": {
+        "name": "default",
+        "children": [
+            {
+                "name": "Redirects",
+                "children": [
+                    {
+                        "name": " LeadGen - prospect ",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "allowPost", "options": { "enabled": true, "allowWithoutContentLength": false } },
+                            { "name": "rewriteUrl", "options": { "behavior": "REWRITE", "targetUrl": "/v1/mkt_lead" } }
+                        ],
+                        "criteria": [
+                            { "name": "path", "options": { "matchOperator": "MATCHES_ONE_OF", "values": ["/v1/prospect"] } },
+                            { "name": "requestMethod", "options": { "matchOperator": "IS", "value": "POST" } }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": " LeadGen - prospect v2",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "allowPost", "options": { "enabled": true, "allowWithoutContentLength": false } },
+                            { "name": "rewriteUrl", "options": { "behavior": "REPLACE", "match": "/v2/prospect/", "targetPath": "/v2/mkt_leads/" } }
+                        ],
+                        "criteria": [
+                            { "name": "path", "options": { "matchOperator": "MATCHES_ONE_OF", "values": ["/v2/prospect/*"] } },
+                            { "name": "requestMethod", "options": { "matchOperator": "IS", "value": "POST" } }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": " LeadGen - activity",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "allowPost", "options": { "enabled": true } },
+                            { "name": "rewriteUrl", "options": { "behavior": "REGEX_REPLACE", "matchRegex": "\\/v1\\/lead_activity\\/?", "targetRegex": "/v1/marketo_new_lead_activity" } }
+                        ],
+                        "criteria": [
+                            { "name": "path", "options": { "matchOperator": "MATCHES_ONE_OF", "values": ["/v1/lead_activity", "/v1/lead_activity/"] } }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": " LeadGen - marketo lead activity- qal",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "allowPost", "options": { "enabled": true } },
+                            { "name": "rewriteUrl", "options": { "behavior": "REGEX_REPLACE", "matchRegex": "\\/qal\\/v1\\/lead_activity\\/?", "targetRegex": "/v1/marketo_new_lead_activity" } },
+                            { "name": "setVariable", "options": { "valueSource": "EXPRESSION", "variableName": "PMUSER_API_ENV", "variableValue": "lgqal" } }
+                        ],
+                        "criteria": [
+                            { "name": "path", "options": { "matchOperator": "MATCHES_ONE_OF", "values": ["/qal/v1/lead_activity", "/qal/v1/lead_activity/"] } }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": " LeadGen - flow service - qal/e2e",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "allowPost", "options": { "enabled": true } },
+                            { "name": "rewriteUrl", "options": { "behavior": "REGEX_REPLACE", "matchRegex": "/flow-service/(.*)/v1/(.*)/(.*)", "targetRegex": "/v1/$2/$3" } },
+                            { "name": "setVariable", "options": { "valueSource": "EXPRESSION", "variableName": "PMUSER_API_ENV", "variableValue": "{{builtin.AK_PATH}}" } }
+                        ],
+                        "criteria": [
+                            { "name": "path", "options": { "matchOperator": "MATCHES_ONE_OF", "values": ["/flow-service/qal/v1/*/getServiceDefinition", "/flow-service/e2e/v1/*/getServiceDefinition", "/flow-service/qal/v1/*/submitAsyncAction", "/flow-service/e2e/v1/*/submitAsyncAction", "/flow-service/qal/v1/*/status", "/flow-service/e2e/v1/*/status", "/flow-service/qal/v1/*/openapi.json", "/flow-service/e2e/v1/*/openapi.json"] } }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all"
+            },
+            {
+                "name": "Augment insights",
+                "children": [
+                    { "name": "Traffic reporting", "children": [], "behaviors": [{ "name": "cpCode", "options": { "value": { "id": 1962249, "name": "martech.intuit.com" } } }], "criteria": [], "criteriaMustSatisfy": "all" },
+                    { "name": "mPulse RUM", "children": [], "behaviors": [{ "name": "mPulse", "options": { "enabled": true, "loaderVersion": "V12" } }], "criteria": [], "criteriaMustSatisfy": "all" },
+                    { "name": "Geolocation", "children": [], "behaviors": [{ "name": "edgeScape", "options": { "enabled": false } }], "criteria": [{ "name": "requestType", "options": { "matchOperator": "IS", "value": "CLIENT_REQ" } }], "criteriaMustSatisfy": "all" },
+                    { "name": "Log delivery", "children": [], "behaviors": [{ "name": "report", "options": { "logHost": false } }], "criteria": [], "criteriaMustSatisfy": "all" }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all"
+            },
+            {
+                "name": "Origin mappings",
+                "children": [
+                    {
+                        "name": "qal",
+                        "children": [
+                            {
+                                "name": "martech-qal.intuit.com origin - leadgen",
+                                "children": [],
+                                "behaviors": [
+                                    { "name": "origin", "options": { "originType": "CUSTOMER", "hostname": "leadgencapability-qal.api.intuit.com" } },
+                                    { "name": "cpCode", "options": { "value": { "id": 1962250, "name": "martech-e2e.intuit.com" } } },
+                                    { "name": "modifyOutgoingRequestHeader", "options": { "action": "MODIFY", "customHeaderName": "Authorization" } }
+                                ],
+                                "criteria": [
+                                    { "name": "hostname", "options": { "matchOperator": "IS_ONE_OF", "values": ["martech-e2e.intuit.com"] } },
+                                    { "name": "matchVariable", "options": { "matchOperator": "IS", "variableName": "PMUSER_API_ENV", "variableExpression": "lgqal" } }
+                                ],
+                                "criteriaMustSatisfy": "all"
+                            },
+                            {
+                                "name": "martech-qal.intuit.com origin - flowservice",
+                                "children": [],
+                                "behaviors": [
+                                    { "name": "origin", "options": { "originType": "CUSTOMER", "hostname": "marketing-flow-svc-qal.api.intuit.com" } },
+                                    { "name": "cpCode", "options": { "value": { "id": 1962250, "name": "martech-e2e.intuit.com" } } }
+                                ],
+                                "criteria": [
+                                    { "name": "hostname", "options": { "matchOperator": "IS_ONE_OF", "values": ["martech-e2e.intuit.com"] } },
+                                    { "name": "matchVariable", "options": { "matchOperator": "IS", "variableName": "PMUSER_API_ENV", "variableExpression": "fsqal" } }
+                                ],
+                                "criteriaMustSatisfy": "all"
+                            }
+                        ],
+                        "behaviors": [],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "e2e",
+                        "children": [
+                            {
+                                "name": "martech-e2e.intuit.com origin - leadGen",
+                                "children": [],
+                                "behaviors": [
+                                    { "name": "origin", "options": { "originType": "CUSTOMER", "hostname": "leadgencapability-e2e.api.intuit.com" } },
+                                    { "name": "cpCode", "options": { "value": { "id": 1962250, "name": "martech-e2e.intuit.com" } } }
+                                ],
+                                "criteria": [
+                                    { "name": "hostname", "options": { "matchOperator": "IS_ONE_OF", "values": ["martech-e2e.intuit.com"] } },
+                                    { "name": "matchVariable", "options": { "matchOperator": "IS", "variableName": "PMUSER_API_ENV", "variableExpression": "NULL" } }
+                                ],
+                                "criteriaMustSatisfy": "all"
+                            },
+                            {
+                                "name": "martech-e2e.intuit.com origin - flowservice",
+                                "children": [],
+                                "behaviors": [
+                                    { "name": "origin", "options": { "originType": "CUSTOMER", "hostname": "marketing-flow-svc-e2e.api.intuit.com" } },
+                                    { "name": "cpCode", "options": { "value": { "id": 1962250, "name": "martech-e2e.intuit.com" } } }
+                                ],
+                                "criteria": [
+                                    { "name": "hostname", "options": { "matchOperator": "IS_ONE_OF", "values": ["martech-e2e.intuit.com"] } },
+                                    { "name": "matchVariable", "options": { "matchOperator": "IS", "variableName": "PMUSER_API_ENV", "variableExpression": "fse2e" } }
+                                ],
+                                "criteriaMustSatisfy": "all"
+                            }
+                        ],
+                        "behaviors": [],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all"
+                    }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all"
+            },
+            {
+                "name": "Accelerate delivery",
+                "children": [
+                    { "name": "Origin connectivity", "children": [], "behaviors": [{ "name": "dnsAsyncRefresh", "options": { "enabled": true } }], "criteria": [], "criteriaMustSatisfy": "all" },
+                    { "name": "Protocol optimizations", "children": [], "behaviors": [{ "name": "http3", "options": { "enable": false } }], "criteria": [], "criteriaMustSatisfy": "all" },
+                    {
+                        "name": "Prefetching",
+                        "children": [
+                            {
+                                "name": "Prefetching objects",
+                                "children": [
+                                    { "name": "Bots", "children": [], "behaviors": [{ "name": "prefetch", "options": { "enabled": false } }], "criteria": [{ "name": "userAgent", "options": { "matchOperator": "IS_ONE_OF", "matchWildcard": true, "values": ["*bot*", "*crawl*", "*spider*"] } }], "criteriaMustSatisfy": "all" }
+                                ],
+                                "behaviors": [{ "name": "prefetch", "options": { "enabled": true } }],
+                                "criteria": [],
+                                "criteriaMustSatisfy": "all"
+                            },
+                            { "name": "Prefetchable objects", "children": [], "behaviors": [{ "name": "prefetchable", "options": { "enabled": true } }], "criteria": [{ "name": "fileExtension", "options": { "matchOperator": "IS_ONE_OF", "values": ["css","js","png"] } }], "criteriaMustSatisfy": "all" }
+                        ],
+                        "behaviors": [],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    { "name": "Adaptive acceleration", "children": [], "behaviors": [{ "name": "adaptiveAcceleration", "options": { "source": "MPULSE" } }], "criteria": [], "criteriaMustSatisfy": "all" }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all"
+            },
+            {
+                "name": "Block Origin Request",
+                "children": [],
+                "behaviors": [
+                    { "name": "constructResponse", "options": { "enabled": true, "responseCode": 404, "body": "Not a valid request." } }
+                ],
+                "criteria": [
+                    { "name": "path", "options": { "matchOperator": "DOES_NOT_MATCH_ONE_OF", "values": ["/v1/prospect", "/v2/prospect/*", "/v1/lead_activity", "/v1/lead_activity/", "/qal/v1/lead_activity", "/flow-service/qal/v1/*/submitAsyncAction", "/flow-service/e2e/v1/*/submitAsyncAction", "/flow-service/qal/v1/*/getServiceDefinition", "/flow-service/qal/v1/*/status", "/flow-service/e2e/v1/*/status", "/flow-service/qal/v1/*/openapi.json", "/flow-service/e2e/v1/*/openapi.json", "/flow-service/e2e/v1/*/getServiceDefinition"] } }
+                ],
+                "criteriaMustSatisfy": "all"
+            },
+            {
+                "name": "Security",
+                "children": [
+                    {
+                        "name": "CORS - OPTION",
+                        "children": [],
+                        "behaviors": [{ "name": "constructResponse", "options": { "enabled": true, "responseCode": 200, "body": "OK" } }],
+                        "criteria": [
+                            { "name": "path", "options": { "matchOperator": "MATCHES_ONE_OF", "values": ["/v1/prospect", "/v2/prospect/*", "/v1/lead_activity", "/v1/lead_activity/"] } },
+                            { "name": "requestMethod", "options": { "matchOperator": "IS", "value": "OPTIONS" } }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "Default CORS Policy",
+                        "children": [],
+                        "behaviors": [{ "name": "modifyOutgoingResponseHeader", "options": { "action": "MODIFY", "standardModifyHeaderName": "ACCESS_CONTROL_ALLOW_ORIGIN" } }],
+                        "criteria": [
+                            { "name": "path", "options": { "matchOperator": "MATCHES_ONE_OF", "values": ["/v1/prospect", "/v1/lead_activity/", "/v1/lead_activity", "/v2/prospect/*"] } }
+                        ],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    {
+                        "name": "CORS origin variable",
+                        "children": [],
+                        "behaviors": [{ "name": "setVariable", "options": { "valueSource": "EXTRACT", "variableName": "PMUSER_CORS_ORIGIN" } }],
+                        "criteria": [{ "name": "requestHeader", "options": { "matchOperator": "IS_ONE_OF", "headerName": "Origin", "values": ["https://quickbooks.intuit.com"] } }],
+                        "criteriaMustSatisfy": "all"
+                    }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all"
+            },
+            {
+                "name": "Offload origin",
+                "children": [
+                    { "name": "CSS and JavaScript", "children": [], "behaviors": [{ "name": "caching", "options": { "behavior": "MAX_AGE", "ttl": "7d" } }], "criteria": [{ "name": "fileExtension", "options": { "matchOperator": "IS_ONE_OF", "values": ["css","js"] } }], "criteriaMustSatisfy": "any" },
+                    { "name": "Images", "children": [], "behaviors": [{ "name": "caching", "options": { "behavior": "MAX_AGE", "ttl": "30d" } }], "criteria": [{ "name": "fileExtension", "options": { "matchOperator": "IS_ONE_OF", "values": ["jpg","png","gif"] } }], "criteriaMustSatisfy": "any" },
+                    { "name": "GraphQL", "children": [], "behaviors": [{ "name": "graphqlCaching", "options": { "enabled": false } }], "criteria": [{ "name": "path", "options": { "matchOperator": "MATCHES_ONE_OF", "values": ["/graphql"] } }], "criteriaMustSatisfy": "all" },
+                    { "name": "Uncacheable objects", "children": [], "behaviors": [{ "name": "downstreamCache", "options": { "behavior": "BUST" } }], "criteria": [{ "name": "cacheability", "options": { "matchOperator": "IS_NOT", "value": "CACHEABLE" } }], "criteriaMustSatisfy": "all" }
+                ],
+                "behaviors": [{ "name": "caching", "options": { "behavior": "NO_STORE" } }],
+                "criteria": [],
+                "criteriaMustSatisfy": "all"
+            },
+            {
+                "name": "Strengthen security",
+                "children": [
+                    {
+                        "name": "Allowed methods",
+                        "children": [
+                            { "name": "POST", "children": [], "behaviors": [{ "name": "allowPost", "options": { "enabled": true } }], "criteria": [], "criteriaMustSatisfy": "all" },
+                            { "name": "OPTIONS", "children": [], "behaviors": [{ "name": "allowOptions", "options": { "enabled": true } }], "criteria": [], "criteriaMustSatisfy": "all" },
+                            { "name": "PUT", "children": [], "behaviors": [{ "name": "allowPut", "options": { "enabled": false } }], "criteria": [], "criteriaMustSatisfy": "all" },
+                            { "name": "DELETE", "children": [], "behaviors": [{ "name": "allowDelete", "options": { "enabled": false } }], "criteria": [], "criteriaMustSatisfy": "all" },
+                            { "name": "PATCH", "children": [], "behaviors": [{ "name": "allowPatch", "options": { "enabled": false } }], "criteria": [], "criteriaMustSatisfy": "all" }
+                        ],
+                        "behaviors": [{ "name": "allHttpInCacheHierarchy", "options": { "enabled": true } }],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all"
+                    },
+                    { "name": "Obfuscate debug info", "children": [], "behaviors": [{ "name": "cacheTagVisible", "options": { "behavior": "PRAGMA_HEADER" } }], "criteria": [], "criteriaMustSatisfy": "all" },
+                    { "name": "HSTS", "children": [], "behaviors": [{ "name": "httpStrictTransportSecurity", "options": { "enable": false } }], "criteria": [], "criteriaMustSatisfy": "all" }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all"
+            },
+            {
+                "name": "Increase availability",
+                "children": [
+                    { "name": "Site failover", "children": [], "behaviors": [{ "name": "failAction", "options": { "enabled": false } }], "criteria": [{ "name": "originTimeout", "options": { "matchOperator": "ORIGIN_TIMED_OUT" } }], "criteriaMustSatisfy": "any" },
+                    { "name": "Origin health", "children": [], "behaviors": [{ "name": "healthDetection", "options": { "retryCount": 3 } }], "criteria": [], "criteriaMustSatisfy": "all" }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all"
+            },
+            {
+                "name": "Minimize payload",
+                "children": [
+                    { "name": "Compressible objects", "children": [], "behaviors": [{ "name": "gzipResponse", "options": { "behavior": "ALWAYS" } }], "criteria": [{ "name": "contentType", "options": { "matchOperator": "IS_ONE_OF", "matchWildcard": true, "values": ["text/*", "application/*json*"] } }], "criteriaMustSatisfy": "all" }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all"
+            }
+        ],
+        "behaviors": [
+            { "name": "origin", "options": { "originType": "CUSTOMER", "hostname": "leadgencapability.api.intuit.com" } },
+            { "name": "allowPost", "options": { "enabled": true, "allowWithoutContentLength": true } },
+            { "name": "modifyOutgoingRequestHeader", "options": { "action": "MODIFY", "customHeaderName": "Authorization" } }
+        ],
+        "options": { "is_secure": true },
+        "variables": [
+            { "name": "PMUSER_API_ENV", "value": "NULL" },
+            { "name": "PMUSER_CORS_ORIGIN", "value": "" }
+        ],
+        "comments": "Default Rule template."
+    }
+}

--- a/tests/property_rule/fixtures/mcp_quickbooks_ion.v4.json
+++ b/tests/property_rule/fixtures/mcp_quickbooks_ion.v4.json
@@ -1,0 +1,735 @@
+{
+    "accountId": "act_1-17WC",
+    "contractId": "ctr_C-19XSR8V",
+    "groupId": "grp_305482",
+    "ruleFormat": "latest",
+    "propertyId": "prp_1350855",
+    "propertyName": "mcp.quickbooks.intuit.com_ion_pm",
+    "propertyVersion": 4,
+    "rules": {
+        "name": "default",
+        "children": [
+            {
+                "name": "Auth Bearer",
+                "children": [],
+                "behaviors": [
+                    {
+                        "name": "modifyOutgoingRequestHeader",
+                        "options": {
+                            "action": "ADD",
+                            "standardAddHeaderName": "OTHER",
+                            "headerValue": "Intuit_IAM_Authentication intuit_appid=\"Intuit.qb.in.3p.qbomcpakamaiclient\",intuit_app_secret=\"REDACTED\",intuit_token_type=\"IAM-Ticket\"",
+                            "customHeaderName": "Authorization"
+                        }
+                    }
+                ],
+                "criteria": [
+                    {
+                        "name": "requestHeader",
+                        "options": {
+                            "matchOperator": "DOES_NOT_EXIST",
+                            "matchWildcardName": false,
+                            "headerName": "Authorization"
+                        }
+                    }
+                ],
+                "criteriaMustSatisfy": "all",
+                "comments": ""
+            },
+            {
+                "name": "Augment insights",
+                "children": [
+                    {
+                        "name": "Traffic reporting",
+                        "children": [],
+                        "behaviors": [
+                            {
+                                "name": "cpCode",
+                                "options": {
+                                    "enableDefaultContentProviderCode": false,
+                                    "value": {
+                                        "id": 2007118,
+                                        "description": "mcp.quickbooks.intuit.com",
+                                        "products": ["Fresca"],
+                                        "name": "mcp.quickbooks.intuit.com"
+                                    }
+                                }
+                            }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Identify your main traffic segments."
+                    },
+                    {
+                        "name": "mPulse RUM",
+                        "children": [],
+                        "behaviors": [
+                            {
+                                "name": "mPulse",
+                                "options": {
+                                    "apiKey": "",
+                                    "enabled": true,
+                                    "loaderVersion": "V12"
+                                }
+                            }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Collect and analyze real-user data."
+                    },
+                    {
+                        "name": "Geolocation",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "edgeScape", "options": { "enabled": false } }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "requestType",
+                                "options": { "matchOperator": "IS", "value": "CLIENT_REQ" }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Receive geolocation data."
+                    },
+                    {
+                        "name": "Log delivery",
+                        "children": [],
+                        "behaviors": [
+                            {
+                                "name": "report",
+                                "options": {
+                                    "logAcceptLanguage": false,
+                                    "logCookies": "OFF",
+                                    "logCustomLogField": false,
+                                    "logEdgeIP": false,
+                                    "logHost": false,
+                                    "logReferer": false,
+                                    "logUserAgent": false,
+                                    "logXForwardedFor": false
+                                }
+                            }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Specify log detail level."
+                    }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all",
+                "comments": "Monitoring and reporting."
+            },
+            {
+                "name": "Accelerate delivery",
+                "children": [
+                    {
+                        "name": "Origin connectivity",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "dnsAsyncRefresh", "options": { "enabled": true, "timeout": "1h" } }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Optimize edge-to-origin connection."
+                    },
+                    {
+                        "name": "Protocol optimizations",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "enhancedAkamaiProtocol", "options": { "display": "" } },
+                            { "name": "http3", "options": { "enable": true } },
+                            { "name": "http2", "options": { "enabled": "" } },
+                            { "name": "allowTransferEncoding", "options": { "enabled": true } },
+                            { "name": "sureRoute", "options": { "enabled": false, "srDownloadLinkTitle": "" } }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Modern fast protocols."
+                    },
+                    {
+                        "name": "Prefetching",
+                        "children": [
+                            {
+                                "name": "Prefetching objects",
+                                "children": [
+                                    {
+                                        "name": "Bots",
+                                        "children": [],
+                                        "behaviors": [
+                                            { "name": "prefetch", "options": { "enabled": false } }
+                                        ],
+                                        "criteria": [
+                                            {
+                                                "name": "userAgent",
+                                                "options": {
+                                                    "matchCaseSensitive": false,
+                                                    "matchOperator": "IS_ONE_OF",
+                                                    "matchWildcard": true,
+                                                    "values": ["*bot*", "*crawl*", "*spider*"]
+                                                }
+                                            }
+                                        ],
+                                        "criteriaMustSatisfy": "all",
+                                        "comments": "Disable prefetch for bots."
+                                    }
+                                ],
+                                "behaviors": [
+                                    { "name": "prefetch", "options": { "enabled": true } }
+                                ],
+                                "criteria": [],
+                                "criteriaMustSatisfy": "all",
+                                "comments": "Enable prefetch for HTML pages."
+                            },
+                            {
+                                "name": "Prefetchable objects",
+                                "children": [],
+                                "behaviors": [
+                                    { "name": "prefetchable", "options": { "enabled": true } }
+                                ],
+                                "criteria": [
+                                    {
+                                        "name": "fileExtension",
+                                        "options": {
+                                            "matchCaseSensitive": false,
+                                            "matchOperator": "IS_ONE_OF",
+                                            "values": ["css","js","jpg","jpeg","jp2","png","gif","svg","svgz","webp","eot","woff","woff2","otf","ttf"]
+                                        }
+                                    }
+                                ],
+                                "criteriaMustSatisfy": "all",
+                                "comments": "Which resources to prefetch."
+                            }
+                        ],
+                        "behaviors": [],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Prefetch embedded resources."
+                    },
+                    {
+                        "name": "Adaptive acceleration",
+                        "children": [],
+                        "behaviors": [
+                            {
+                                "name": "adaptiveAcceleration",
+                                "options": {
+                                    "abLogic": "DISABLED",
+                                    "enableBrotliCompression": true,
+                                    "enablePreconnect": true,
+                                    "enablePush": true,
+                                    "preloadEnable": true,
+                                    "source": "MPULSE"
+                                }
+                            }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "ML performance optimizations."
+                    }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all",
+                "comments": "Performance of delivering objects."
+            },
+            {
+                "name": "Offload origin",
+                "children": [
+                    {
+                        "name": "CSS and JavaScript",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "caching", "options": { "behavior": "MAX_AGE", "mustRevalidate": false, "ttl": "7d" } }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "fileExtension",
+                                "options": { "matchCaseSensitive": false, "matchOperator": "IS_ONE_OF", "values": ["css","js"] }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "any",
+                        "comments": "Cache CSS/JS."
+                    },
+                    {
+                        "name": "Fonts",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "caching", "options": { "behavior": "MAX_AGE", "mustRevalidate": false, "ttl": "30d" } }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "fileExtension",
+                                "options": { "matchCaseSensitive": false, "matchOperator": "IS_ONE_OF", "values": ["eot","woff","woff2","otf","ttf"] }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "any",
+                        "comments": "Cache fonts."
+                    },
+                    {
+                        "name": "Images",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "caching", "options": { "behavior": "MAX_AGE", "mustRevalidate": false, "ttl": "30d" } }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "fileExtension",
+                                "options": { "matchCaseSensitive": false, "matchOperator": "IS_ONE_OF", "values": ["jpg","jpeg","png","gif","webp","jp2","ico","svg","svgz"] }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "any",
+                        "comments": "Cache images."
+                    },
+                    {
+                        "name": "Files",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "caching", "options": { "behavior": "MAX_AGE", "mustRevalidate": false, "ttl": "7d" } }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "fileExtension",
+                                "options": { "matchCaseSensitive": false, "matchOperator": "IS_ONE_OF", "values": ["pdf","doc","docx","odt"] }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "any",
+                        "comments": "Cache files."
+                    },
+                    {
+                        "name": "Other static objects",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "caching", "options": { "behavior": "MAX_AGE", "mustRevalidate": false, "ttl": "7d" } }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "fileExtension",
+                                "options": { "matchCaseSensitive": false, "matchOperator": "IS_ONE_OF", "values": ["aif","aiff","au","avi","bin","bmp","txt","zip","tif","tiff","mid","jar"] }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "any",
+                        "comments": "Cache other static."
+                    },
+                    {
+                        "name": "HTML pages",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "caching", "options": { "behavior": "NO_STORE" } },
+                            {
+                                "name": "cacheKeyQueryParams",
+                                "options": {
+                                    "behavior": "IGNORE",
+                                    "exactMatch": true,
+                                    "parameters": ["gclid","fbclid","utm_source","utm_campaign","utm_medium","utm_content"]
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "fileExtension",
+                                "options": { "matchCaseSensitive": false, "matchOperator": "IS_ONE_OF", "values": ["html","htm","php","jsp","aspx","EMPTY_STRING"] }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Cache HTML."
+                    },
+                    {
+                        "name": "Redirects",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "cacheRedirect", "options": { "enabled": "false" } }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Cache redirects."
+                    },
+                    {
+                        "name": "POST responses",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "cachePost", "options": { "enabled": false } }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Cache POST."
+                    },
+                    {
+                        "name": "GraphQL",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "graphqlCaching", "options": { "enabled": false } }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "path",
+                                "options": {
+                                    "matchCaseSensitive": false,
+                                    "matchOperator": "MATCHES_ONE_OF",
+                                    "normalize": false,
+                                    "values": ["/graphql"]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Cache GraphQL."
+                    },
+                    {
+                        "name": "Uncacheable objects",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "downstreamCache", "options": { "behavior": "BUST" } }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "cacheability",
+                                "options": { "matchOperator": "IS_NOT", "value": "CACHEABLE" }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Uncacheable content."
+                    }
+                ],
+                "behaviors": [
+                    { "name": "caching", "options": { "behavior": "NO_STORE" } },
+                    { "name": "tieredDistribution", "options": { "enabled": false } }
+                ],
+                "criteria": [],
+                "criteriaMustSatisfy": "all",
+                "comments": "Caching at edge and browser."
+            },
+            {
+                "name": "Strengthen security",
+                "children": [
+                    {
+                        "name": "Allowed methods",
+                        "children": [
+                            {
+                                "name": "POST",
+                                "children": [],
+                                "behaviors": [
+                                    { "name": "allowPost", "options": { "allowWithoutContentLength": false, "enabled": true } }
+                                ],
+                                "criteria": [],
+                                "criteriaMustSatisfy": "all",
+                                "comments": "Allow POST."
+                            },
+                            {
+                                "name": "OPTIONS",
+                                "children": [],
+                                "behaviors": [
+                                    { "name": "allowOptions", "options": { "enabled": true } }
+                                ],
+                                "criteria": [],
+                                "criteriaMustSatisfy": "all",
+                                "comments": "Allow OPTIONS."
+                            },
+                            {
+                                "name": "PUT",
+                                "children": [],
+                                "behaviors": [
+                                    { "name": "allowPut", "options": { "enabled": false } }
+                                ],
+                                "criteria": [],
+                                "criteriaMustSatisfy": "all",
+                                "comments": "Allow PUT."
+                            },
+                            {
+                                "name": "DELETE",
+                                "children": [],
+                                "behaviors": [
+                                    { "name": "allowDelete", "options": { "enabled": false } }
+                                ],
+                                "criteria": [],
+                                "criteriaMustSatisfy": "all",
+                                "comments": "Allow DELETE."
+                            },
+                            {
+                                "name": "PATCH",
+                                "children": [],
+                                "behaviors": [
+                                    { "name": "allowPatch", "options": { "enabled": false } }
+                                ],
+                                "criteria": [],
+                                "criteriaMustSatisfy": "all",
+                                "comments": "Allow PATCH."
+                            }
+                        ],
+                        "behaviors": [
+                            { "name": "allHttpInCacheHierarchy", "options": { "enabled": true } }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Allow HTTP methods."
+                    },
+                    {
+                        "name": "Obfuscate debug info",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "cacheTagVisible", "options": { "behavior": "PRAGMA_HEADER" } }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Hide back-end info."
+                    },
+                    {
+                        "name": "Obfuscate backend info",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "modifyOutgoingResponseHeader", "options": { "action": "DELETE", "customHeaderName": "X-Powered-By", "standardDeleteHeaderName": "OTHER" } },
+                            { "name": "modifyOutgoingResponseHeader", "options": { "action": "DELETE", "customHeaderName": "Server", "standardDeleteHeaderName": "OTHER" } }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "requestHeader",
+                                "options": {
+                                    "headerName": "X-Akamai-Debug",
+                                    "matchCaseSensitiveValue": true,
+                                    "matchOperator": "IS_NOT_ONE_OF",
+                                    "matchWildcardName": false,
+                                    "matchWildcardValue": false,
+                                    "values": ["true"]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Hide back-end info unless secret header."
+                    },
+                    {
+                        "name": "HSTS",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "httpStrictTransportSecurity", "options": { "enable": false } }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Require HTTPS."
+                    }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all",
+                "comments": "Minimize info shared with clients."
+            },
+            {
+                "name": "Increase availability",
+                "children": [
+                    {
+                        "name": "Simulate failover",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "breakConnection", "options": { "enabled": true } }
+                        ],
+                        "criteria": [
+                            { "name": "contentDeliveryNetwork", "options": { "matchOperator": "IS", "network": "STAGING" } },
+                            {
+                                "name": "requestHeader",
+                                "options": {
+                                    "headerName": "breakconnection",
+                                    "matchCaseSensitiveValue": true,
+                                    "matchOperator": "IS_ONE_OF",
+                                    "matchWildcardName": false,
+                                    "matchWildcardValue": false,
+                                    "values": ["Your-Secret-Here"]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Simulate origin problem on staging."
+                    },
+                    {
+                        "name": "Site failover",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "failAction", "options": { "enabled": false } }
+                        ],
+                        "criteria": [
+                            { "name": "originTimeout", "options": { "matchOperator": "ORIGIN_TIMED_OUT" } }
+                        ],
+                        "criteriaMustSatisfy": "any",
+                        "comments": "Respond when origin unavailable."
+                    },
+                    {
+                        "name": "Origin health",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "healthDetection", "options": { "maximumReconnects": 2, "retryCount": 3, "retryInterval": "10s" } }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Monitor origin health."
+                    },
+                    {
+                        "name": "Script management",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "scriptManagement", "options": { "enabled": false } }
+                        ],
+                        "criteria": [],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Manage third-party JS."
+                    }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all",
+                "comments": "Respond when origin/3p slow or down."
+            },
+            {
+                "name": "Minimize payload",
+                "children": [
+                    {
+                        "name": "Compressible objects",
+                        "children": [],
+                        "behaviors": [
+                            { "name": "gzipResponse", "options": { "behavior": "ALWAYS" } }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "contentType",
+                                "options": {
+                                    "matchCaseSensitive": false,
+                                    "matchOperator": "IS_ONE_OF",
+                                    "matchWildcard": true,
+                                    "values": ["application/*javascript*","application/*json*","application/*xml*","text/*","font/otf","image/svg+xml"]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all",
+                        "comments": "Gzip text formats."
+                    }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all",
+                "comments": "Reduce content size."
+            },
+            {
+                "name": "Origins",
+                "children": [
+                    {
+                        "name": "Cloudfront",
+                        "children": [],
+                        "behaviors": [
+                            {
+                                "name": "origin",
+                                "options": {
+                                    "originType": "CUSTOMER",
+                                    "forwardHostHeader": "ORIGIN_HOSTNAME",
+                                    "cacheKeyHostname": "ORIGIN_HOSTNAME",
+                                    "ipVersion": "IPV4",
+                                    "compress": true,
+                                    "enableTrueClientIp": true,
+                                    "trueClientIpHeader": "True-Client-IP",
+                                    "verificationMode": "CUSTOM",
+                                    "originSni": true,
+                                    "httpPort": 80,
+                                    "httpsPort": 443,
+                                    "minTlsVersion": "DYNAMIC",
+                                    "hostname": "d2l8cmvpwpdfrn.cloudfront.net",
+                                    "customValidCnValues": ["{{Origin Hostname}}", "{{Forward Host Header}}"],
+                                    "originCertsToHonor": "STANDARD_CERTIFICATE_AUTHORITIES",
+                                    "standardCertificateAuthorities": ["akamai-permissive"]
+                                }
+                            }
+                        ],
+                        "criteria": [
+                            {
+                                "name": "path",
+                                "options": {
+                                    "matchOperator": "MATCHES_ONE_OF",
+                                    "matchCaseSensitive": false,
+                                    "normalize": false,
+                                    "values": ["/web_assets/*"]
+                                }
+                            }
+                        ],
+                        "criteriaMustSatisfy": "all",
+                        "comments": ""
+                    }
+                ],
+                "behaviors": [],
+                "criteria": [],
+                "criteriaMustSatisfy": "all",
+                "comments": ""
+            },
+            {
+                "name": "IP Allow List",
+                "children": [],
+                "behaviors": [
+                    {
+                        "name": "requestControl",
+                        "options": {
+                            "enabled": true,
+                            "isSharedPolicy": true,
+                            "enableBranded403": false,
+                            "cloudletSharedPolicy": 317486
+                        }
+                    }
+                ],
+                "criteria": [
+                    {
+                        "name": "hostname",
+                        "options": {
+                            "matchOperator": "IS_ONE_OF",
+                            "values": ["mcp.quickbooks.intuit.com"]
+                        }
+                    },
+                    {
+                        "name": "path",
+                        "options": {
+                            "matchOperator": "DOES_NOT_MATCH_ONE_OF",
+                            "matchCaseSensitive": false,
+                            "normalize": false,
+                            "values": ["/web_assets/*"]
+                        }
+                    }
+                ],
+                "criteriaMustSatisfy": "all",
+                "comments": ""
+            }
+        ],
+        "behaviors": [
+            {
+                "name": "origin",
+                "options": {
+                    "cacheKeyHostname": "REQUEST_HOST_HEADER",
+                    "compress": true,
+                    "enableTrueClientIp": true,
+                    "forwardHostHeader": "REQUEST_HOST_HEADER",
+                    "httpPort": 80,
+                    "httpsPort": 443,
+                    "minTlsVersion": "DYNAMIC",
+                    "originSni": true,
+                    "originType": "CUSTOMER",
+                    "verificationMode": "CUSTOM",
+                    "trueClientIpHeader": "True-Client-IP",
+                    "hostname": "qbo-mcp-federation.api.intuit.com",
+                    "ipVersion": "IPV4",
+                    "customValidCnValues": ["{{Origin Hostname}}", "{{Forward Host Header}}"],
+                    "originCertsToHonor": "STANDARD_CERTIFICATE_AUTHORITIES",
+                    "standardCertificateAuthorities": ["akamai-permissive"]
+                }
+            },
+            {
+                "name": "enhancedDebug",
+                "options": { "enableDebug": true, "generateGrn": true, "disablePragma": true }
+            },
+            {
+                "name": "cpCode",
+                "options": {
+                    "enableDefaultContentProviderCode": false,
+                    "value": { "id": 2007090, "description": "mcp.quickbooks.intuit.com", "products": ["Fresca"], "name": "mcp.quickbooks.intuit.com" }
+                }
+            },
+            {
+                "name": "siteShield",
+                "options": {
+                    "ssmap": { "name": "ss_prod_apigw (s2990.akamaiedge.net)", "value": "s2990.akamaiedge.net" }
+                }
+            }
+        ],
+        "options": { "is_secure": true },
+        "variables": [],
+        "comments": "Default Rule template."
+    }
+}

--- a/tests/property_rule/test_property_rule.py
+++ b/tests/property_rule/test_property_rule.py
@@ -62,6 +62,8 @@ def _make_record(
     origin_hostname="backend.example.com",
     rule_name="v1-api",
     rule_depth=1,
+    rule_path="0",
+    full_path="default/v1-api",
 ):
     return PropertyRuleRecord(
         path=path,
@@ -74,6 +76,8 @@ def _make_record(
         baseDirectory=None,
         ruleName=rule_name,
         ruleDepth=rule_depth,
+        rulePath=rule_path,
+        fullPath=full_path,
         criteriaMustSatisfy="all",
         securityBehaviors=[],
         propertyId=property_id,
@@ -145,10 +149,11 @@ async def test_extract_records_rule_tree_raises_continues():
 
 @pytest.mark.asyncio
 async def test_extract_records_path_eligible_rule():
-    """A path-eligible record (path set) produces a non-null pathKey."""
+    """A path-eligible record (path set) produces a non-null pathKey and,
+    because Path XOR Rule, a NULL ruleKey (it is a Path node only)."""
     extractor = _make_extractor()
     property = _make_property()
-    record = _make_record(path="/v1/*", path_criteria=["/v1/*"])
+    record = _make_record(path="/v1/*", path_criteria=["/v1/*"], rule_path="0")
     extractor.client.list_all_properties = Mock(return_value=[property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
     extractor.client.extractRuleRecords = Mock(return_value=[record])
@@ -158,19 +163,17 @@ async def test_extract_records_path_eligible_rule():
     assert len(results) == 1
     d = results[0]
     assert d["pathKey"] == {"proxy_id": "prp_123", "path": "/v1/*"}
-    assert d["ruleKey"] == {
-        "proxy_id": "prp_123",
-        "rule_name": "v1-api",
-        "hostname": None,
-    }
+    # Path XOR Rule: a path-eligible rule is a Path node ONLY, never also a Rule.
+    assert d["ruleKey"] is None
 
 
 @pytest.mark.asyncio
-async def test_extract_records_non_path_rule_pathkey_none():
-    """A non-path rule (path=None) produces pathKey=None."""
+async def test_extract_records_non_path_rule_becomes_rule_node_keyed_on_rule_path():
+    """A non-path rule (path=None) produces pathKey=None and a ruleKey keyed on
+    (proxy_id, rule_path) — the tree position, NOT rule_name/hostname."""
     extractor = _make_extractor()
     property = _make_property()
-    record = _make_record(path=None, path_criteria=[])
+    record = _make_record(path=None, path_criteria=[], rule_path="3.1")
     extractor.client.list_all_properties = Mock(return_value=[property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
     extractor.client.extractRuleRecords = Mock(return_value=[record])
@@ -178,17 +181,46 @@ async def test_extract_records_non_path_rule_pathkey_none():
     results = [x async for x in extractor.extract_records()]
 
     assert len(results) == 1
-    assert results[0]["pathKey"] is None
+    d = results[0]
+    assert d["pathKey"] is None
+    assert d["ruleKey"] == {"proxy_id": "prp_123", "rule_path": "3.1"}
+    # rule_name / hostname must NOT be part of the key (they are not unique)
+    assert "rule_name" not in d["ruleKey"]
+    assert "hostname" not in d["ruleKey"]
 
 
 @pytest.mark.asyncio
-async def test_extract_records_rulekey_includes_hostname():
-    """ruleKey.hostname is the first hostnameCriteria value when present."""
+async def test_extract_records_rule_key_is_unique_by_tree_position():
+    """Two rules with the SAME name+hostname but different tree positions must
+    get DISTINCT ruleKeys — the exact collision the old key produced."""
+    extractor = _make_extractor()
+    property = _make_property()
+    # same rule_name, same (empty) hostname, different rule_path — a real
+    # collision under the old (proxy_id, rule_name, hostname) key.
+    records = [
+        _make_record(path=None, rule_name="US", rule_path="2.0.0"),
+        _make_record(path=None, rule_name="US", rule_path="2.1.0"),
+    ]
+    extractor.client.list_all_properties = Mock(return_value=[property])
+    extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
+    extractor.client.extractRuleRecords = Mock(return_value=records)
+
+    results = [x async for x in extractor.extract_records()]
+
+    keys = [r["ruleKey"]["rule_path"] for r in results]
+    assert keys == ["2.0.0", "2.1.0"]
+    assert len(set(keys)) == 2  # distinct — no collision
+
+
+@pytest.mark.asyncio
+async def test_extract_records_full_path_surfaced_on_record():
+    """full_path (name breadcrumb) is carried through as a record field."""
     extractor = _make_extractor()
     property = _make_property()
     record = _make_record(
-        path="/v1/*",
-        hostname_criteria=["api.example.com", "api2.example.com"],
+        path=None,
+        rule_path="2.0.0",
+        full_path="default/Origin mappings/qal/leadgen",
     )
     extractor.client.list_all_properties = Mock(return_value=[property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
@@ -196,22 +228,7 @@ async def test_extract_records_rulekey_includes_hostname():
 
     results = [x async for x in extractor.extract_records()]
 
-    assert results[0]["ruleKey"]["hostname"] == "api.example.com"
-
-
-@pytest.mark.asyncio
-async def test_extract_records_rulekey_hostname_none_when_no_criteria():
-    """ruleKey.hostname is None when hostnameCriteria is empty."""
-    extractor = _make_extractor()
-    property = _make_property()
-    record = _make_record(path=None, hostname_criteria=[])
-    extractor.client.list_all_properties = Mock(return_value=[property])
-    extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
-    extractor.client.extractRuleRecords = Mock(return_value=[record])
-
-    results = [x async for x in extractor.extract_records()]
-
-    assert results[0]["ruleKey"]["hostname"] is None
+    assert results[0]["fullPath"] == "default/Origin mappings/qal/leadgen"
 
 
 @pytest.mark.asyncio

--- a/tests/property_rule/test_property_rule.py
+++ b/tests/property_rule/test_property_rule.py
@@ -62,7 +62,7 @@ def _make_record(
     origin_hostname="backend.example.com",
     rule_name="v1-api",
     rule_depth=1,
-    rule_path="0",
+    rule_path="/rules/children/0",
     full_path="default/v1-api",
 ):
     return PropertyRuleRecord(
@@ -153,7 +153,9 @@ async def test_extract_records_path_eligible_rule():
     because Path XOR Rule, a NULL ruleKey (it is a Path node only)."""
     extractor = _make_extractor()
     property = _make_property()
-    record = _make_record(path="/v1/*", path_criteria=["/v1/*"], rule_path="0")
+    record = _make_record(
+        path="/v1/*", path_criteria=["/v1/*"], rule_path="/rules/children/0"
+    )
     extractor.client.list_all_properties = Mock(return_value=[property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
     extractor.client.extractRuleRecords = Mock(return_value=[record])
@@ -173,7 +175,9 @@ async def test_extract_records_non_path_rule_becomes_rule_node_keyed_on_rule_pat
     (proxy_id, rule_path) — the tree position, NOT rule_name/hostname."""
     extractor = _make_extractor()
     property = _make_property()
-    record = _make_record(path=None, path_criteria=[], rule_path="3.1")
+    record = _make_record(
+        path=None, path_criteria=[], rule_path="/rules/children/3/children/1"
+    )
     extractor.client.list_all_properties = Mock(return_value=[property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
     extractor.client.extractRuleRecords = Mock(return_value=[record])
@@ -183,7 +187,10 @@ async def test_extract_records_non_path_rule_becomes_rule_node_keyed_on_rule_pat
     assert len(results) == 1
     d = results[0]
     assert d["pathKey"] is None
-    assert d["ruleKey"] == {"proxy_id": "prp_123", "rule_path": "3.1"}
+    assert d["ruleKey"] == {
+        "proxy_id": "prp_123",
+        "rule_path": "/rules/children/3/children/1",
+    }
     # rule_name / hostname must NOT be part of the key (they are not unique)
     assert "rule_name" not in d["ruleKey"]
     assert "hostname" not in d["ruleKey"]
@@ -198,8 +205,12 @@ async def test_extract_records_rule_key_is_unique_by_tree_position():
     # same rule_name, same (empty) hostname, different rule_path — a real
     # collision under the old (proxy_id, rule_name, hostname) key.
     records = [
-        _make_record(path=None, rule_name="US", rule_path="2.0.0"),
-        _make_record(path=None, rule_name="US", rule_path="2.1.0"),
+        _make_record(
+            path=None, rule_name="US", rule_path="/rules/children/2/children/0"
+        ),
+        _make_record(
+            path=None, rule_name="US", rule_path="/rules/children/3/children/0"
+        ),
     ]
     extractor.client.list_all_properties = Mock(return_value=[property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
@@ -208,7 +219,10 @@ async def test_extract_records_rule_key_is_unique_by_tree_position():
     results = [x async for x in extractor.extract_records()]
 
     keys = [r["ruleKey"]["rule_path"] for r in results]
-    assert keys == ["2.0.0", "2.1.0"]
+    assert keys == [
+        "/rules/children/2/children/0",
+        "/rules/children/3/children/0",
+    ]
     assert len(set(keys)) == 2  # distinct — no collision
 
 
@@ -219,7 +233,7 @@ async def test_extract_records_full_path_surfaced_on_record():
     property = _make_property()
     record = _make_record(
         path=None,
-        rule_path="2.0.0",
+        rule_path="/rules/children/2/children/0",
         full_path="default/Origin mappings/qal/leadgen",
     )
     extractor.client.list_all_properties = Mock(return_value=[property])

--- a/tests/property_rule/test_property_rule.py
+++ b/tests/property_rule/test_property_rule.py
@@ -12,8 +12,7 @@ Covers all branches of extract_records:
   - rule with no hostname criteria → ruleKey.hostname is None
 """
 
-import dataclasses
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from requests import HTTPError
@@ -152,11 +151,11 @@ async def test_extract_records_path_eligible_rule():
     """A path-eligible record (path set) produces a non-null pathKey and,
     because Path XOR Rule, a NULL ruleKey (it is a Path node only)."""
     extractor = _make_extractor()
-    property = _make_property()
+    akamai_property = _make_property()
     record = _make_record(
         path="/v1/*", path_criteria=["/v1/*"], rule_path="/rules/children/0"
     )
-    extractor.client.list_all_properties = Mock(return_value=[property])
+    extractor.client.list_all_properties = Mock(return_value=[akamai_property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
     extractor.client.extractRuleRecords = Mock(return_value=[record])
 
@@ -174,11 +173,11 @@ async def test_extract_records_non_path_rule_becomes_rule_node_keyed_on_rule_pat
     """A non-path rule (path=None) produces pathKey=None and a ruleKey keyed on
     (proxy_id, rule_path) — the tree position, NOT rule_name/hostname."""
     extractor = _make_extractor()
-    property = _make_property()
+    akamai_property = _make_property()
     record = _make_record(
         path=None, path_criteria=[], rule_path="/rules/children/3/children/1"
     )
-    extractor.client.list_all_properties = Mock(return_value=[property])
+    extractor.client.list_all_properties = Mock(return_value=[akamai_property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
     extractor.client.extractRuleRecords = Mock(return_value=[record])
 
@@ -201,7 +200,7 @@ async def test_extract_records_rule_key_is_unique_by_tree_position():
     """Two rules with the SAME name+hostname but different tree positions must
     get DISTINCT ruleKeys — the exact collision the old key produced."""
     extractor = _make_extractor()
-    property = _make_property()
+    akamai_property = _make_property()
     # same rule_name, same (empty) hostname, different rule_path — a real
     # collision under the old (proxy_id, rule_name, hostname) key.
     records = [
@@ -212,7 +211,7 @@ async def test_extract_records_rule_key_is_unique_by_tree_position():
             path=None, rule_name="US", rule_path="/rules/children/3/children/0"
         ),
     ]
-    extractor.client.list_all_properties = Mock(return_value=[property])
+    extractor.client.list_all_properties = Mock(return_value=[akamai_property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
     extractor.client.extractRuleRecords = Mock(return_value=records)
 
@@ -230,13 +229,13 @@ async def test_extract_records_rule_key_is_unique_by_tree_position():
 async def test_extract_records_full_path_surfaced_on_record():
     """full_path (name breadcrumb) is carried through as a record field."""
     extractor = _make_extractor()
-    property = _make_property()
+    akamai_property = _make_property()
     record = _make_record(
         path=None,
         rule_path="/rules/children/2/children/0",
         full_path="default/Origin mappings/qal/leadgen",
     )
-    extractor.client.list_all_properties = Mock(return_value=[property])
+    extractor.client.list_all_properties = Mock(return_value=[akamai_property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
     extractor.client.extractRuleRecords = Mock(return_value=[record])
 
@@ -249,9 +248,11 @@ async def test_extract_records_full_path_surfaced_on_record():
 async def test_extract_records_deeplink_constructed_correctly():
     """deeplink is built from assetId, version, and groupId."""
     extractor = _make_extractor()
-    property = _make_property(asset_id="99999", production_version=7, group_id="grp_42")
+    akamai_property = _make_property(
+        asset_id="99999", production_version=7, group_id="grp_42"
+    )
     record = _make_record()
-    extractor.client.list_all_properties = Mock(return_value=[property])
+    extractor.client.list_all_properties = Mock(return_value=[akamai_property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
 
     captured_deeplink = {}
@@ -274,12 +275,12 @@ async def test_extract_records_deeplink_constructed_correctly():
 async def test_extract_records_multiple_records_from_one_property():
     """Multiple rule records from a single property are all yielded."""
     extractor = _make_extractor()
-    property = _make_property()
+    akamai_property = _make_property()
     records = [
         _make_record(path="/v1/*", rule_name="v1"),
         _make_record(path=None, rule_name="default", rule_depth=0),
     ]
-    extractor.client.list_all_properties = Mock(return_value=[property])
+    extractor.client.list_all_properties = Mock(return_value=[akamai_property])
     extractor.client.get_rule_tree = Mock(return_value={"rules": {}})
     extractor.client.extractRuleRecords = Mock(return_value=records)
 

--- a/tests/property_rule/test_rule_key_uniqueness.py
+++ b/tests/property_rule/test_rule_key_uniqueness.py
@@ -13,7 +13,7 @@ breadcrumb) as a readable property. It also makes Path XOR AkamaiPropertyRule
 (a rule is one node type, never both).
 
 These tests run the REAL extractor (AkamaiPropertyClient.extractRuleRecords +
-AkamaiPropertyRuleExtractor.buildPathKey/buildRuleKey) against real, downloaded
+AkamaiPropertyRuleExtractor.build_path_key/build_rule_key) against real, downloaded
 production rule trees and assert:
 
   1. the OLD key (proxy_id, rule_name, hostname) COLLIDES (documents the bug),
@@ -64,8 +64,8 @@ def _extract(tree):
         deeplink="",
     ):
         rec = dataclasses.asdict(rr)
-        rec["pathKey"] = ext.buildPathKey(rec)
-        rec["ruleKey"] = ext.buildRuleKey(rec)
+        rec["pathKey"] = ext.build_path_key(rec)
+        rec["ruleKey"] = ext.build_rule_key(rec)
         records.append(rec)
     return records
 

--- a/tests/property_rule/test_rule_key_uniqueness.py
+++ b/tests/property_rule/test_rule_key_uniqueness.py
@@ -1,0 +1,185 @@
+"""Regression tests proving the AkamaiPropertyRule key fix on real rule trees.
+
+Background
+----------
+The original key (proxy_id, rule_name, hostname) was NOT unique: Akamai rule
+names repeat across a property's rule tree and hostname is null for most rules.
+This produced duplicate AkamaiPropertyRule nodes that could not satisfy a NODE
+KEY constraint (Neo.DatabaseError.Schema.ConstraintCreationFailed in prod).
+
+The fix keys AkamaiPropertyRule on (proxy_id, rule_path) — the rule's ordinal
+tree position, which is unique by construction — and carries full_path (name
+breadcrumb) as a readable property. It also makes Path XOR AkamaiPropertyRule
+(a rule is one node type, never both).
+
+These tests run the REAL extractor (AkamaiPropertyClient.extractRuleRecords +
+AkamaiPropertyRuleExtractor.buildPathKey/buildRuleKey) against real, downloaded
+production rule trees and assert:
+
+  1. the OLD key (proxy_id, rule_name, hostname) COLLIDES (documents the bug),
+  2. the NEW key (proxy_id, rule_path) is UNIQUE (proves the fix),
+  3. Path XOR Rule — every record is exactly one bucket,
+  4. negative path matches (DOES_NOT_MATCH_ONE_OF) are preserved as !-globs,
+  5. full_path is populated and readable.
+"""
+
+import dataclasses
+import json
+import os
+from collections import Counter
+
+import pytest
+
+from nodestream_akamai.akamai_utils.property_client import AkamaiPropertyClient
+from nodestream_akamai.property_rule import AkamaiPropertyRuleExtractor
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+TREES = [
+    "leadgencapability_pm.v21.json",  # qal/e2e sibling rules with repeated names
+    "mcp_quickbooks_ion.v4.json",  # already-unique names (regression guard)
+]
+
+
+def _load(name):
+    with open(os.path.join(FIXTURES, name)) as f:
+        return json.load(f)
+
+
+def _extract(tree):
+    """Run the real extractor over a rule tree and return pipeline record dicts."""
+    client = AkamaiPropertyClient(
+        base_url="https://x",
+        client_token="x",
+        client_secret="x",
+        access_token="x",
+        account_key=None,
+    )
+    ext = AkamaiPropertyRuleExtractor.__new__(AkamaiPropertyRuleExtractor)
+    records = []
+    for rr in client.extractRuleRecords(
+        rule=tree["rules"],
+        propertyId=tree["propertyId"],
+        propertyName=tree["propertyName"],
+        version=tree["propertyVersion"],
+        deeplink="",
+    ):
+        rec = dataclasses.asdict(rr)
+        rec["pathKey"] = ext.buildPathKey(rec)
+        rec["ruleKey"] = ext.buildRuleKey(rec)
+        records.append(rec)
+    return records
+
+
+def _old_key(rec):
+    """The removed key (proxy_id, rule_name, first-hostname)."""
+    host = rec["hostnameCriteria"][0] if rec["hostnameCriteria"] else None
+    return (rec["propertyId"], rec["ruleName"], host)
+
+
+@pytest.mark.parametrize("tree_name", TREES)
+def test_new_key_proxy_id_rule_path_is_unique(tree_name):
+    """(proxy_id, rule_path) is unique across the whole tree -> constraint creatable."""
+    records = _extract(_load(tree_name))
+    keys = [
+        (r["propertyId"], r["rulePath"]) for r in records if r["ruleKey"] is not None
+    ]
+    dupes = [k for k, c in Counter(keys).items() if c > 1]
+    assert not dupes, f"(proxy_id, rule_path) collisions in {tree_name}: {dupes}"
+
+
+@pytest.mark.parametrize("tree_name", TREES)
+def test_path_xor_rule_never_both(tree_name):
+    """Every record is EITHER a Path node OR an AkamaiPropertyRule, never both."""
+    records = _extract(_load(tree_name))
+    both = [r for r in records if r["pathKey"] is not None and r["ruleKey"] is not None]
+    assert not both, f"{len(both)} records are BOTH Path and Rule in {tree_name}"
+    for r in records:
+        assert (r["pathKey"] is None) != (
+            r["ruleKey"] is None
+        ), f"record {r['ruleName']} ({r['rulePath']}) is not exactly one bucket"
+
+
+@pytest.mark.parametrize("tree_name", TREES)
+def test_full_path_is_populated_and_contains_rule_name(tree_name):
+    records = _extract(_load(tree_name))
+    for r in records:
+        assert r["fullPath"], f"empty full_path for {r['ruleName']}"
+        assert r["ruleName"] in r["fullPath"]
+
+
+def test_old_key_collides_but_new_key_does_not():
+    """The exact production bug (Neo.DatabaseError.Schema.ConstraintCreationFailed):
+    two rules named 'US' at different tree positions, both path-less/hostname-less.
+
+    The OLD key (proxy_id, rule_name, hostname) maps both to the SAME key and
+    collides. The NEW key (proxy_id, rule_path) keeps them distinct.
+    """
+    records = _extract(_load("collision_repro.json"))
+    rule_records = [r for r in records if r["ruleKey"] is not None]
+
+    # both 'US' rules are present as distinct rule nodes
+    us = [r for r in rule_records if r["ruleName"] == "US"]
+    assert len(us) == 2, f"expected two 'US' rules, got {len(us)}"
+
+    old_keys = [_old_key(r) for r in us]
+    new_keys = [(r["propertyId"], r["rulePath"]) for r in us]
+
+    # OLD key: identical -> would violate NODE KEY (this is the bug)
+    assert (
+        len(set(old_keys)) == 1
+    ), f"expected old key collision, got distinct {old_keys}"
+    # NEW key: distinct -> constraint creatable (this is the fix)
+    assert (
+        len(set(new_keys)) == 2
+    ), f"new key must distinguish the two 'US' rules, got {new_keys}"
+
+
+def test_leadgen_sibling_origin_rules_get_distinct_paths():
+    """qal/... and e2e/... origin rules share names but must be distinct nodes,
+    disambiguated purely by tree position."""
+    records = _extract(_load("leadgencapability_pm.v21.json"))
+    by_name = {}
+    for r in records:
+        if "origin - flowservice" in r["ruleName"]:
+            by_name.setdefault(r["ruleName"], set()).add(r["rulePath"])
+    # the two 'flowservice' rules (qal + e2e) exist and have different rule_paths
+    all_paths = {p for paths in by_name.values() for p in paths}
+    assert (
+        len(all_paths) >= 2
+    ), f"expected distinct tree positions for sibling origin rules, got {by_name}"
+
+
+def test_negative_path_criteria_preserved_as_negated_glob():
+    """'Block Origin Request' uses DOES_NOT_MATCH_ONE_OF; every value must be
+    stored as a !-prefixed glob (switch on match operator works as intended)."""
+    records = _extract(_load("leadgencapability_pm.v21.json"))
+    block = next((r for r in records if r["ruleName"] == "Block Origin Request"), None)
+    assert block is not None, "Block Origin Request rule missing"
+    negated = [p for p in block["pathCriteria"] if p.startswith("!")]
+    assert negated, f"expected negated globs, got {block['pathCriteria']}"
+    # all of its criteria are negative -> all values must be !-prefixed
+    assert all(
+        p.startswith("!") for p in block["pathCriteria"]
+    ), f"mixed/incorrect negation encoding: {block['pathCriteria']}"
+
+
+def test_positive_path_criteria_not_negated():
+    """A positive MATCHES_ONE_OF rule ('GraphQL' -> /graphql) must NOT be negated."""
+    records = _extract(_load("mcp_quickbooks_ion.v4.json"))
+    gql = next((r for r in records if r["ruleName"] == "GraphQL"), None)
+    assert gql is not None, "GraphQL rule missing"
+    assert "/graphql" in gql["pathCriteria"]
+    assert not any(
+        p.startswith("!") for p in gql["pathCriteria"]
+    ), f"positive match was wrongly negated: {gql['pathCriteria']}"
+
+
+def test_cloudfront_path_rule_routes_to_origin_as_path_node():
+    """Origins/Cloudfront (/web_assets/* + origin) is a Path node, ROUTES_TO cf,
+    content preserved."""
+    records = _extract(_load("mcp_quickbooks_ion.v4.json"))
+    cf = next((r for r in records if r["ruleName"] == "Cloudfront"), None)
+    assert cf is not None
+    assert cf["pathKey"] is not None and cf["ruleKey"] is None  # Path node only
+    assert "/web_assets/*" in cf["pathCriteria"]
+    assert cf["originHostname"] == "d2l8cmvpwpdfrn.cloudfront.net"

--- a/tests/property_rule/test_rule_key_uniqueness.py
+++ b/tests/property_rule/test_rule_key_uniqueness.py
@@ -104,7 +104,59 @@ def test_full_path_is_populated_and_contains_rule_name(tree_name):
     records = _extract(_load(tree_name))
     for r in records:
         assert r["fullPath"], f"empty full_path for {r['ruleName']}"
-        assert r["ruleName"] in r["fullPath"]
+        # full_path sanitizes "/" in names to "_", so compare the sanitized name
+        assert r["ruleName"].replace("/", "_") in r["fullPath"]
+
+
+def test_full_path_sanitizes_slashes_in_rule_names():
+    """Rule names are free text and may contain '/'. In full_path (only), each
+    name segment's '/' is replaced with '_' so the '/' separator is unambiguous.
+    rule_name and rule_path are unaffected."""
+    tree = {
+        "propertyId": "prp_x",
+        "propertyName": "p",
+        "propertyVersion": 1,
+        "rules": {
+            "name": "default",
+            "behaviors": [
+                {
+                    "name": "origin",
+                    "options": {"originType": "CUSTOMER", "hostname": "o.example.com"},
+                }
+            ],
+            "criteria": [],
+            "children": [
+                {
+                    "name": "option/1",  # <- slash inside the name
+                    "behaviors": [],
+                    "criteria": [],
+                    "children": [
+                        {
+                            "name": "leaf/a/b",
+                            "behaviors": [],
+                            "criteria": [],
+                            "children": [],
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+    records = _extract(tree)
+    by_name = {r["ruleName"]: r for r in records}
+
+    # rule_name stays raw (unsanitized)
+    assert "option/1" in by_name
+    assert "leaf/a/b" in by_name
+
+    # full_path replaces "/" within each name segment with "_", keeping "/" only
+    # as the genuine level separator
+    assert by_name["option/1"]["fullPath"] == "default/option_1"
+    assert by_name["leaf/a/b"]["fullPath"] == "default/option_1/leaf_a_b"
+
+    # rule_path (the key) is unaffected — pure index JSON Pointer
+    assert by_name["option/1"]["rulePath"] == "/rules/children/0"
+    assert by_name["leaf/a/b"]["rulePath"] == "/rules/children/0/children/0"
 
 
 def test_old_key_collides_but_new_key_does_not():


### PR DESCRIPTION
fix(property-rule): key AkamaiPropertyRule on (proxy_id, rule_path), not (proxy_id, rule_name, hostname)

The AkamaiPropertyRule node key (proxy_id, rule_name, hostname) is not unique: Akamai rule names repeat across a property's rule tree (many rules are named "US", "default", "Blog_Origin", etc.) and hostname is null for the majority of rules (those not under a hostname section). This produced duplicate AkamaiPropertyRule nodes that cannot satisfy a NODE KEY constraint — in production this surfaced as Neo.DatabaseError.Schema.ConstraintCreationFailed, which wedged the whole ingest migration.

Fix:
- Key AkamaiPropertyRule on (proxy_id, rule_path). rule_path is the rule's ordinal tree position ("ROOT", "3.0", "3.0.1", ...), computed during the existing recursive walk. A rule tree is an ordered array, so tree position is unique by construction and stable across ingests for a property version.
- Carry full_path (the name breadcrumb, e.g. "default/Origin mappings/qal/martech-qal.intuit.com origin - leadgen") as a readable node property for querying.
- Make Path XOR AkamaiPropertyRule: buildRuleKey returns None for path-eligible rules, so each rule is written as exactly one node type. Previously ruleKey was always built, so every path-bearing rule was written as BOTH a Path and an AkamaiPropertyRule node.

Negation/origin/criteria-inheritance handling is unchanged — those were correct and remain so (verified: negative path matches stay !-prefixed, positive stay plain).

Tests:
- tests/property_rule/test_rule_key_uniqueness.py runs the real extractor over real downloaded production rule trees (leadgencapability_pm v21, mcp.quickbooks.intuit.com_ion_pm v4) plus a minimal collision repro, and asserts: old key collides / new key is unique, Path XOR Rule, negation preserved, positive-match not negated, full_path populated, sibling origin rules get distinct tree positions.
- tests/property_rule/test_property_rule.py updated to the new key contract.